### PR TITLE
Add mongo utilities with collection script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Rename to .env in your local copy to customize
+# Below are the default values
+PORT=3000
+HOST='localhost'
+DATABASE_NAME='mongodb://localhost:27017/measure-repository'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         node-version: [16.x]
-        mongodb-version: ['5.0']
+        mongodb-version: ['6.0']
 
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist
 node_modules
+.env

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A prototype implementation of a [FHIR Measure Repository Service](https://build.
 ## Prerequisites
 
 - [Node.js >=16.0.0](https://nodejs.org/en/)
-- [MongoDB >= 5.0](https://www.mongodb.com)
+- [MongoDB >= 6.0](https://www.mongodb.com)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,26 @@
 
 A prototype implementation of a [FHIR Measure Repository Service](https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html)
 
+## Prerequisites
+
+- [Node.js >=16.0.0](https://nodejs.org/en/)
+- [MongoDB >= 5.0](https://www.mongodb.com)
+
+## Usage
+
+```
+npm start
+```
+
+### First time Database Setup
+
+This server comes with a script to create collections for FHIR Measure, Library, and MeasureReport resources which will be used by the measure repository service.
+To create these collections:
+
+```
+npm run db:setup
+```
+
 ## License
 
 Copyright 2022 The MITRE Corporation

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@projecttacoma/node-fhir-server-core": "^2.2.8"
+        "@projecttacoma/node-fhir-server-core": "^2.2.8",
+        "dotenv": "^16.0.3",
+        "mongodb": "^4.12.1"
       },
       "devDependencies": {
         "@types/fhir": "^0.0.35",
@@ -4400,6 +4402,14 @@
       "integrity": "sha512-ZjI4zqTaxveH2/tTlzS1wFp+7ncxNZaIEWYg3lzZRHkKf5zPT/MnEG6WL0BhHMJUabkh8GeU5NL5j+rEUCb7Ug==",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -12481,6 +12491,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/dont-sniff-mimetype/-/dont-sniff-mimetype-1.1.0.tgz",
       "integrity": "sha512-ZjI4zqTaxveH2/tTlzS1wFp+7ncxNZaIEWYg3lzZRHkKf5zPT/MnEG6WL0BhHMJUabkh8GeU5NL5j+rEUCb7Ug=="
+    },
+    "dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -5,14 +5,17 @@
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
-    "build:watch": "tsc -p tsconfig.build.json -w",
-    "lint": "eslint \"src/**/*.{js,ts}\"",
-    "lint:fix": "eslint \"src/**/*.{js,ts}\" --fix",
-    "prettier": "prettier --check \"src/**/*.{js,ts}\"",
+    "build": "tsc -p ./tsconfig.build.json",
+    "build:watch": "tsc -p ./tsconfig.build.json -w",
+    "db:delete": "ts-node ./scripts/dbSetup.ts delete",
+    "db:reset": "ts-node ./scripts/dbSetup.ts reset",
+    "db:setup": "ts-node ./scripts/dbSetup.ts create",
+    "lint": "eslint \"./src/**/*.{js,ts}\"",
+    "lint:fix": "eslint \"./src/**/*.{js,ts}\" --fix",
+    "prettier": "prettier --check \"./src/**/*.{js,ts}\"",
     "prettier:fix": "prettier --write \"src/**/*.{js,ts}\"",
-    "start": "ts-node src/index.ts",
-    "start:watch": "nodemon src/index.ts",
+    "start": "ts-node ./src/index.ts",
+    "start:watch": "nodemon ./src/index.ts",
     "test": "jest",
     "test:watch": "jest --watch"
   },
@@ -32,6 +35,8 @@
     "typescript": "^4.9.3"
   },
   "dependencies": {
-    "@projecttacoma/node-fhir-server-core": "^2.2.8"
+    "@projecttacoma/node-fhir-server-core": "^2.2.8",
+    "dotenv": "^16.0.3",
+    "mongodb": "^4.12.1"
   }
 }

--- a/scripts/dbSetup.ts
+++ b/scripts/dbSetup.ts
@@ -1,0 +1,62 @@
+import { Connection } from '../src/db/Connection';
+
+const DB_URL = process.env.DATABASE_URL || 'mongodb://localhost:27017/measure-repository';
+const COLLECTION_NAMES = ['Measure', 'Library', 'MeasureReport'];
+
+async function createCollections() {
+  await Connection.connect(DB_URL);
+  console.log(`Connected to ${DB_URL}`);
+
+  const creations = COLLECTION_NAMES.map(async cn => {
+    console.log(`Creating collection ${cn}`);
+    await (await Connection.db.createCollection(cn)).createIndex({ id: 1 }, { unique: true });
+  });
+
+  await Promise.all(creations);
+}
+
+async function deleteCollections() {
+  await Connection.connect(DB_URL);
+  console.log(`Connected to ${DB_URL}`);
+
+  const collections = await Connection.db.listCollections().toArray();
+  const deletions = collections.map(async c => {
+    console.log(`Deleting collection ${c.name}`);
+    await Connection.db.dropCollection(c.name);
+  });
+  await Promise.all(deletions);
+}
+
+if (process.argv[2] === 'delete') {
+  deleteCollections()
+    .then(() => {
+      console.log('Done');
+    })
+    .catch(console.error)
+    .finally(() => {
+      Connection.connection?.close();
+    });
+} else if (process.argv[2] === 'create') {
+  createCollections()
+    .then(() => {
+      console.log('Done');
+    })
+    .catch(console.error)
+    .finally(() => {
+      Connection.connection?.close();
+    });
+} else if (process.argv[2] === 'reset') {
+  deleteCollections()
+    .then(() => {
+      return createCollections();
+    })
+    .then(() => {
+      console.log('Done');
+    })
+    .catch(console.error)
+    .finally(() => {
+      Connection.connection?.close();
+    });
+} else {
+  console.log('Usage: ts-node src/scripts/dbSetup.ts <create|delete|reset>');
+}

--- a/src/db/Connection.ts
+++ b/src/db/Connection.ts
@@ -1,0 +1,17 @@
+import { Db, MongoClient, MongoClientOptions } from 'mongodb';
+
+export class Connection {
+  static connection: MongoClient | null = null;
+  static db: Db;
+
+  static async connect(url: string, options?: MongoClientOptions) {
+    if (this.connection != null) {
+      return this.connection;
+    }
+
+    this.connection = await MongoClient.connect(url, options ?? {});
+    this.db = this.connection.db();
+
+    return this.connection;
+  }
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["test"]
+  "exclude": ["test", "scripts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "target": "ES2017",
     "module": "commonJS",
     "outDir": "./dist",
-    "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
* Add singleton class for mongo connections that can be re-used across the app
* Add scripts for `npm run db:setup`, `npm run db:delete`, and `npm run db:reset` similar to deqm-test-server, but they only deal with collections for Measure, Library, and MeasureReport

Example usage of the database connection can be seen in the scripts. Test them out, run the server, etc.