### PR TITLE
Measure $package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "db:delete": "ts-node ./scripts/dbSetup.ts delete",
     "db:reset": "ts-node ./scripts/dbSetup.ts reset",
     "db:setup": "ts-node ./scripts/dbSetup.ts create",
+    "db:loadBundle": "ts-node ./scripts/dbSetup.ts loadBundle",
     "lint": "eslint \"./src/**/*.{js,ts}\"",
     "lint:fix": "eslint \"./src/**/*.{js,ts}\" --fix",
     "prettier": "prettier --check \"./src/**/*.{js,ts}\"",

--- a/scripts/dbSetup.ts
+++ b/scripts/dbSetup.ts
@@ -1,4 +1,7 @@
 import { Connection } from '../src/db/Connection';
+import * as fs from 'fs';
+import { Bundle, FhirResource } from 'fhir/r4';
+import { MongoError, OptionalId } from 'mongodb';
 
 const DB_URL = process.env.DATABASE_URL || 'mongodb://localhost:27017/measure-repository';
 const COLLECTION_NAMES = ['Measure', 'Library', 'MeasureReport'];
@@ -27,6 +30,66 @@ async function deleteCollections() {
   await Promise.all(deletions);
 }
 
+/*
+ * Loads all measure or library resources found in the bundle located at param filePath
+ */
+async function loadBundle(filePath: string) {
+  await Connection.connect(DB_URL);
+  console.log(`Connected to ${DB_URL}`);
+  console.log(`Loading bundle from path ${filePath}`);
+
+  const data = fs.readFileSync(filePath, 'utf8');
+  if (data) {
+    console.log(`Uploading ${filePath.split('/').slice(-1)}...`);
+    const bundle: Bundle = JSON.parse(data);
+    // retrieve each resource and insert into database
+    if (bundle.entry) {
+      let resourcesUploaded = 0;
+      const uploads = bundle.entry.map(async res => {
+        // Only upload Library or Measure resources
+        if (
+          res?.resource?.resourceType &&
+          (res?.resource?.resourceType === 'Library' || res?.resource?.resourceType === 'Measure')
+        ) {
+          try {
+            await createResource(res.resource, res.resource.resourceType);
+            resourcesUploaded += 1;
+          } catch (e) {
+            // ignore duplicate key errors for Libraries, Note: if ValueSets added, also ignore for those
+            if (!(e instanceof MongoError && e.code == 11000 && res.resource.resourceType === 'Library')) {
+              if (e instanceof Error) {
+                console.error(e.message);
+              } else {
+                console.error(String(e));
+              }
+            }
+          }
+        } else {
+          console.log(
+            res?.resource?.resourceType
+              ? `Not loading resource of type ${res?.resource?.resourceType}`
+              : 'Resource or resource type undefined'
+          );
+        }
+      });
+      await Promise.all(uploads);
+      console.log(`${resourcesUploaded} resources uploaded.`);
+    } else {
+      console.error('Unable to identify bundle entries.');
+    }
+  }
+}
+
+/*
+ * Inserts one data object into database with specified FHIR resource type
+ */
+async function createResource(data: FhirResource, resourceType: string) {
+  const collection = Connection.db.collection<fhir4.FhirResource>(resourceType);
+  console.log(`Inserting ${resourceType}/${data.id} into database`);
+  await collection.insertOne(data);
+  return { id: data.id };
+}
+
 if (process.argv[2] === 'delete') {
   deleteCollections()
     .then(() => {
@@ -50,6 +113,18 @@ if (process.argv[2] === 'delete') {
     .then(() => {
       return createCollections();
     })
+    .then(() => {
+      console.log('Done');
+    })
+    .catch(console.error)
+    .finally(() => {
+      Connection.connection?.close();
+    });
+} else if (process.argv[2] === 'loadBundle') {
+  if (process.argv.length < 4) {
+    throw new Error('Filename argument required.');
+  }
+  loadBundle(process.argv[3])
     .then(() => {
       console.log('Done');
     })

--- a/scripts/dbSetup.ts
+++ b/scripts/dbSetup.ts
@@ -1,7 +1,6 @@
 import { Connection } from '../src/db/Connection';
 import * as fs from 'fs';
-import { Bundle, FhirResource } from 'fhir/r4';
-import { MongoError, OptionalId } from 'mongodb';
+import { MongoError } from 'mongodb';
 
 const DB_URL = process.env.DATABASE_URL || 'mongodb://localhost:27017/measure-repository';
 const COLLECTION_NAMES = ['Measure', 'Library', 'MeasureReport'];
@@ -41,7 +40,7 @@ async function loadBundle(filePath: string) {
   const data = fs.readFileSync(filePath, 'utf8');
   if (data) {
     console.log(`Uploading ${filePath.split('/').slice(-1)}...`);
-    const bundle: Bundle = JSON.parse(data);
+    const bundle: fhir4.Bundle = JSON.parse(data);
     // retrieve each resource and insert into database
     if (bundle.entry) {
       let resourcesUploaded = 0;
@@ -83,7 +82,7 @@ async function loadBundle(filePath: string) {
 /*
  * Inserts one data object into database with specified FHIR resource type
  */
-async function createResource(data: FhirResource, resourceType: string) {
+async function createResource(data: fhir4.FhirResource, resourceType: string) {
   const collection = Connection.db.collection<fhir4.FhirResource>(resourceType);
   console.log(`Inserting ${resourceType}/${data.id} into database`);
   await collection.insertOne(data);

--- a/scripts/dbSetup.ts
+++ b/scripts/dbSetup.ts
@@ -44,6 +44,7 @@ async function loadBundle(filePath: string) {
     // retrieve each resource and insert into database
     if (bundle.entry) {
       let resourcesUploaded = 0;
+      let notUploaded = 0;
       const uploads = bundle.entry.map(async res => {
         // Only upload Library or Measure resources
         if (
@@ -64,15 +65,16 @@ async function loadBundle(filePath: string) {
             }
           }
         } else {
-          console.log(
-            res?.resource?.resourceType
-              ? `Not loading resource of type ${res?.resource?.resourceType}`
-              : 'Resource or resource type undefined'
-          );
+          if (res?.resource?.resourceType) {
+            notUploaded += 1;
+          } else {
+            console.log('Resource or resource type undefined');
+          }
         }
       });
       await Promise.all(uploads);
       console.log(`${resourcesUploaded} resources uploaded.`);
+      console.log(`${notUploaded} non-Measure/non-Library resources skipped.`);
     } else {
       console.error('Unable to identify bundle entries.');
     }

--- a/src/config/serverConfig.ts
+++ b/src/config/serverConfig.ts
@@ -5,7 +5,33 @@ export const serverConfig: ServerConfig = {
   profiles: {
     Measure: {
       service: new MeasureService(),
-      versions: [constants.VERSIONS['4_0_1']]
+      versions: [constants.VERSIONS['4_0_1']],
+      operation: [
+        {
+          name: 'package',
+          route: '/$package',
+          method: 'GET',
+          reference: 'https://build.fhir.org/ig/HL7/cqf-measures/OperationDefinition-Measure-package.html'
+        },
+        {
+          name: 'package',
+          route: '/$package',
+          method: 'POST',
+          reference: 'https://build.fhir.org/ig/HL7/cqf-measures/OperationDefinition-Measure-package.html'
+        },
+        {
+          name: 'package',
+          route: '/:id/$package',
+          method: 'GET',
+          reference: 'https://build.fhir.org/ig/HL7/cqf-measures/OperationDefinition-Measure-package.html'
+        },
+        {
+          name: 'package',
+          route: '/:id/$package',
+          method: 'POST',
+          reference: 'https://build.fhir.org/ig/HL7/cqf-measures/OperationDefinition-Measure-package.html'
+        }
+      ]
     },
     Library: {
       service: new LibraryService(),

--- a/src/config/serverConfig.ts
+++ b/src/config/serverConfig.ts
@@ -11,25 +11,25 @@ export const serverConfig: ServerConfig = {
           name: 'package',
           route: '/$package',
           method: 'GET',
-          reference: 'https://build.fhir.org/ig/HL7/cqf-measures/OperationDefinition-Measure-package.html'
+          reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Measure-package'
         },
         {
           name: 'package',
           route: '/$package',
           method: 'POST',
-          reference: 'https://build.fhir.org/ig/HL7/cqf-measures/OperationDefinition-Measure-package.html'
+          reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Measure-package'
         },
         {
           name: 'package',
           route: '/:id/$package',
           method: 'GET',
-          reference: 'https://build.fhir.org/ig/HL7/cqf-measures/OperationDefinition-Measure-package.html'
+          reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Measure-package'
         },
         {
           name: 'package',
           route: '/:id/$package',
           method: 'POST',
-          reference: 'https://build.fhir.org/ig/HL7/cqf-measures/OperationDefinition-Measure-package.html'
+          reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Measure-package'
         }
       ]
     },

--- a/src/services/LibraryService.ts
+++ b/src/services/LibraryService.ts
@@ -35,7 +35,7 @@ export class LibraryService implements Service<fhir4.Library> {
     logger.info(`GET /Library/${args.id}`);
     const result = await findResourceById<fhir4.Library>(args.id, 'Library');
     if (!result) {
-      throw new ResourceNotFoundError(`No resource found in collection: Library, with: id ${args.id}`);
+      throw new ResourceNotFoundError(`No resource found in collection: Library, with id: ${args.id}`);
     }
     return result;
   }

--- a/src/services/MeasureService.ts
+++ b/src/services/MeasureService.ts
@@ -73,6 +73,6 @@ export class MeasureService implements Service<fhir4.Measure> {
     }
 
     // TODO: should we allow multiple measure matches?
-    return await createMeasurePackageBundle(measure[0]);
+    return createMeasurePackageBundle(measure[0]);
   }
 }

--- a/src/services/MeasureService.ts
+++ b/src/services/MeasureService.ts
@@ -71,8 +71,14 @@ export class MeasureService implements Service<fhir4.Measure> {
           .join(' and ')}`
       );
     }
+    if (measure.length > 1) {
+      throw new BadRequestError(
+        `Multiple resources found in collection: Measure, with: ${Object.keys(query)
+          .map(key => `${key}: ${query[key]}`)
+          .join(' and ')}. /Measure/$package operation must specify a single Measure`
+      );
+    }
 
-    // TODO: should we allow multiple measure matches?
     return createMeasurePackageBundle(measure[0]);
   }
 }

--- a/src/services/MeasureService.ts
+++ b/src/services/MeasureService.ts
@@ -48,7 +48,6 @@ export class MeasureService implements Service<fhir4.Measure> {
    */
   async package(args: RequestArgs, ctx: RequestCtx) {
     logger.info(`${ctx.req.method} to ${ctx.req.path}`);
-    console.log('ARGS!! matey', args.resource);
 
     const params = gatherParams(ctx.req.query, args.resource);
     const id = args.id || params.id;

--- a/src/services/MeasureService.ts
+++ b/src/services/MeasureService.ts
@@ -1,8 +1,8 @@
-import { loggers, RequestArgs, RequestCtx, resolveSchema } from '@projecttacoma/node-fhir-server-core';
+import { loggers, RequestArgs, RequestCtx } from '@projecttacoma/node-fhir-server-core';
 import { Filter } from 'mongodb';
 import { findResourceById, findResourcesWithQuery } from '../db/dbOperations';
 import { Service } from '../types/service';
-import { createSearchsetBundle } from '../util/bundleUtils';
+import { createMeasurePackageBundle, createSearchsetBundle } from '../util/bundleUtils';
 import { BadRequestError, ResourceNotFoundError } from '../util/errorUtils';
 import { getMongoQueryFromRequest } from '../util/queryUtils';
 import { gatherParams, validateSearchParams } from '../util/validationUtils';
@@ -65,12 +65,11 @@ export class MeasureService implements Service<fhir4.Measure> {
     if (url) query.url = url;
     if (version) query.version = version;
     const measure = await findResourcesWithQuery<fhir4.Measure>(query, 'Measure');
-    if (!measure) {
+    if (!measure || !(measure.length > 0)) {
       throw new ResourceNotFoundError(`No resource found in collection: Measure, with: id ${args.id}`);
     }
 
-    // TODO: gather dependencies and create bundle
-    // const result = resolveSchema('4_0_1', 'Bundle') as fhir4.Bundle;
-    return measure;
+    // TODO: should we allow multiple measure matches?
+    return await createMeasurePackageBundle(measure[0]);
   }
 }

--- a/src/services/MeasureService.ts
+++ b/src/services/MeasureService.ts
@@ -36,15 +36,16 @@ export class MeasureService implements Service<fhir4.Measure> {
     logger.info(`GET /Measure/${args.id}`);
     const result = await findResourceById<fhir4.Measure>(args.id, 'Measure');
     if (!result) {
-      throw new ResourceNotFoundError(`No resource found in collection: Measure, with: id ${args.id}`);
+      throw new ResourceNotFoundError(`No resource found in collection: Measure, with id: ${args.id}`);
     }
     return result;
   }
 
   /**
-   * result of sending a POST or GET request to {BASE_URL}/4_0_1/Measure/$package or {BASE_URL}/4_0_1/Measure/:id/$package
+   * result of sending a POST or GET request to:
+   * {BASE_URL}/4_0_1/Measure/$package or {BASE_URL}/4_0_1/Measure/:id/$package
    * creates a bundle of the measure (specified by parameters) and all dependent libraries
-   * supports parameters id and/or url + version (optional)
+   * requires parameters id and/or url, but also supports version as supplemental (optional)
    */
   async package(args: RequestArgs, { req }: RequestCtx) {
     logger.info(`${req.method} ${req.path}`);
@@ -66,14 +67,14 @@ export class MeasureService implements Service<fhir4.Measure> {
     const measure = await findResourcesWithQuery<fhir4.Measure>(query, 'Measure');
     if (!measure || !(measure.length > 0)) {
       throw new ResourceNotFoundError(
-        `No resource found in collection: Measure, with: ${Object.keys(query)
+        `No resource found in collection: Measure, with ${Object.keys(query)
           .map(key => `${key}: ${query[key]}`)
           .join(' and ')}`
       );
     }
     if (measure.length > 1) {
       throw new BadRequestError(
-        `Multiple resources found in collection: Measure, with: ${Object.keys(query)
+        `Multiple resources found in collection: Measure, with ${Object.keys(query)
           .map(key => `${key}: ${query[key]}`)
           .join(' and ')}. /Measure/$package operation must specify a single Measure`
       );

--- a/src/services/MeasureService.ts
+++ b/src/services/MeasureService.ts
@@ -46,10 +46,10 @@ export class MeasureService implements Service<fhir4.Measure> {
    * creates a bundle of the measure (specified by parameters) and all dependent libraries
    * supports parameters id and/or url + version (optional)
    */
-  async package(args: RequestArgs, ctx: RequestCtx) {
-    logger.info(`${ctx.req.method} to ${ctx.req.path}`);
+  async package(args: RequestArgs, { req }: RequestCtx) {
+    logger.info(`${req.method} ${req.path}`);
 
-    const params = gatherParams(ctx.req.query, args.resource);
+    const params = gatherParams(req.query, args.resource);
     const id = args.id || params.id;
     const url = params.url;
     const version = params.version;

--- a/src/services/MeasureService.ts
+++ b/src/services/MeasureService.ts
@@ -1,10 +1,11 @@
-import { loggers, RequestArgs, RequestCtx } from '@projecttacoma/node-fhir-server-core';
+import { loggers, RequestArgs, RequestCtx, resolveSchema } from '@projecttacoma/node-fhir-server-core';
+import { Filter } from 'mongodb';
 import { findResourceById, findResourcesWithQuery } from '../db/dbOperations';
 import { Service } from '../types/service';
 import { createSearchsetBundle } from '../util/bundleUtils';
-import { ResourceNotFoundError } from '../util/errorUtils';
+import { BadRequestError, ResourceNotFoundError } from '../util/errorUtils';
 import { getMongoQueryFromRequest } from '../util/queryUtils';
-import { validateSearchParams } from '../util/validationUtils';
+import { gatherParams, validateSearchParams } from '../util/validationUtils';
 
 const logger = loggers.get('default');
 
@@ -38,5 +39,38 @@ export class MeasureService implements Service<fhir4.Measure> {
       throw new ResourceNotFoundError(`No resource found in collection: Measure, with: id ${args.id}`);
     }
     return result;
+  }
+
+  /**
+   * result of sending a POST or GET request to {BASE_URL}/4_0_1/Measure/$package or {BASE_URL}/4_0_1/Measure/:id/$package
+   * creates a bundle of the measure (specified by parameters) and all dependent libraries
+   * supports parameters id and/or url + version (optional)
+   */
+  async package(args: RequestArgs, ctx: RequestCtx) {
+    logger.info(`${ctx.req.method} to ${ctx.req.path}`);
+    console.log('ARGS!! matey', args.resource);
+
+    const params = gatherParams(ctx.req.query, args.resource);
+    const id = args.id || params.id;
+    const url = params.url;
+    const version = params.version;
+
+    if (!id && !url) {
+      throw new BadRequestError('Must provide identifying information via either id or url parameters');
+    }
+
+    // query construction
+    const query: Filter<any> = {};
+    if (id) query.id = id;
+    if (url) query.url = url;
+    if (version) query.version = version;
+    const measure = await findResourcesWithQuery<fhir4.Measure>(query, 'Measure');
+    if (!measure) {
+      throw new ResourceNotFoundError(`No resource found in collection: Measure, with: id ${args.id}`);
+    }
+
+    // TODO: gather dependencies and create bundle
+    // const result = resolveSchema('4_0_1', 'Bundle') as fhir4.Bundle;
+    return measure;
   }
 }

--- a/src/services/MeasureService.ts
+++ b/src/services/MeasureService.ts
@@ -65,7 +65,11 @@ export class MeasureService implements Service<fhir4.Measure> {
     if (version) query.version = version;
     const measure = await findResourcesWithQuery<fhir4.Measure>(query, 'Measure');
     if (!measure || !(measure.length > 0)) {
-      throw new ResourceNotFoundError(`No resource found in collection: Measure, with: id ${args.id}`);
+      throw new ResourceNotFoundError(
+        `No resource found in collection: Measure, with: ${Object.keys(query)
+          .map(key => `${key}: ${query[key]}`)
+          .join(' and ')}`
+      );
     }
 
     // TODO: should we allow multiple measure matches?

--- a/src/util/bundleUtils.ts
+++ b/src/util/bundleUtils.ts
@@ -31,7 +31,6 @@ export async function createMeasurePackageBundle(measure: fhir4.Measure): Promis
     const [mainLibraryRef] = measure.library;
     const mainLibQuery = getQueryFromReference(mainLibraryRef);
     const libs = await findResourcesWithQuery(mainLibQuery, 'Library');
-    console.log(libs);
     if (!libs || libs.length < 1) {
       throw new ResourceNotFoundError(`Could not find Library ${mainLibraryRef} referenced by Measure ${measure.id}`);
     }
@@ -93,7 +92,6 @@ export async function getAllDependentLibraries(lib: fhir4.Library): Promise<fhir
     const libQuery = getQueryFromReference(url);
     const libs = await findResourcesWithQuery(libQuery, 'Library');
     if (!libs || libs.length < 1) {
-      console.log('reached');
       throw new ResourceNotFoundError(
         `Failed to find dependent library with ${
           libQuery.id ? `id: ${libQuery.id}` : `canonical url: ${libQuery.url}`

--- a/src/util/bundleUtils.ts
+++ b/src/util/bundleUtils.ts
@@ -1,4 +1,11 @@
+import { loggers } from '@projecttacoma/node-fhir-server-core';
+import { FhirResource, Library } from 'fhir/r4';
+import { Filter } from 'mongodb';
 import { v4 } from 'uuid';
+import { findResourcesWithQuery } from '../db/dbOperations';
+import { ResourceNotFoundError } from '../util/errorUtils';
+
+const logger = loggers.get('default');
 
 /**
  * Takes in an array of FHIR resources and creates a FHIR searchset Bundle with the
@@ -13,4 +20,98 @@ export function createSearchsetBundle<T extends fhir4.FhirResource>(entries: T[]
     total: entries.length,
     entry: entries.map(e => ({ resource: e }))
   };
+}
+
+/**
+ * Takes in a measure resource, finds all dependent library resources and bundles them
+ * together with the measure in a collection bundle
+ */
+export async function createMeasurePackageBundle(measure: fhir4.Measure): Promise<fhir4.Bundle<FhirResource>> {
+  logger.info(`Assembling collection bundle from Measure ${measure.id}`);
+  if (measure.library && measure.library.length > 0) {
+    const [mainLibraryRef] = measure.library;
+    const mainLibQuery = getQueryFromReference(mainLibraryRef);
+    const libs = await findResourcesWithQuery(mainLibQuery, 'Library');
+
+    if (!libs || libs.length < 1) {
+      throw new ResourceNotFoundError(`Could not find Library ${mainLibraryRef} referenced by Measure ${measure.id}`);
+    }
+    const mainLib = libs[0];
+
+    const allLibsDups = await getAllDependentLibraries(mainLib as Library);
+    // de-dup by id using map
+    const idMap = new Map(allLibsDups.map(lib => [lib.id, lib]));
+    const allLibs = Array.from(idMap.values());
+    const result: fhir4.Bundle = { resourceType: 'Bundle', type: 'collection' };
+    result.entry = allLibs.map(r => ({
+      resource: r
+    }));
+    return result;
+  } else {
+    throw new ResourceNotFoundError(`No libraries found for measure ${measure.id}`);
+  }
+}
+
+/**
+ * Assemble a mongo query based on a reference to another resource
+ * @param {string} reference assumed to be canonical
+ * @returns {Filter} mongo query to pass in to mongo controller to search for the referenced resource
+ */
+function getQueryFromReference(reference: string): Filter<any> {
+  // References could be canonical or resourceType/id
+  if (reference.includes('|')) {
+    const [urlPart, versionPart] = reference.split('|');
+    return { url: urlPart, version: versionPart };
+  } else {
+    return { url: reference };
+  }
+}
+
+/**
+ * Iterate through relatedArtifact of library and return list of all dependent libraries used
+ */
+async function getAllDependentLibraries(lib: Library): Promise<Library[]> {
+  logger.debug(`Retrieving all dependent libraries for library: ${lib.id}`);
+  const results = [lib];
+
+  // If the library has no dependencies, we are done
+  if (!lib.relatedArtifact || (Array.isArray(lib.relatedArtifact) && lib.relatedArtifact.length === 0)) {
+    return results;
+  }
+
+  // This filter checks for the 'Library' keyword on all related artifacts
+  const depLibUrls = lib.relatedArtifact
+    .filter(
+      ra =>
+        ra.type === 'depends-on' &&
+        ra.resource?.includes('Library') &&
+        ra.resource !== 'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'
+    ) // exclude modelinfo dependency
+    .map(ra => ra.resource as string); //TODO: may be able to improve this typing
+  // Obtain all libraries referenced in the related artifact, and recurse on their dependencies
+  const libraryGets = depLibUrls.map(async url => {
+    // TODO: remove if not needed -> Quick fix for invalid connectathon url references
+    // if (url in INCORRECT_CONNECTATHON_URLS_MAP) {
+    //   logger.warn(
+    //     `Using potentially outdated reference url: ${url}. Replacing with ${INCORRECT_CONNECTATHON_URLS_MAP[url]}`
+    //   );
+    //   url = INCORRECT_CONNECTATHON_URLS_MAP[url];
+    // }
+    const libQuery = getQueryFromReference(url);
+    const libs = await findResourcesWithQuery(libQuery, 'Library');
+    if (!libs || libs.length < 1) {
+      throw new ResourceNotFoundError(
+        `Failed to find dependent library with ${
+          libQuery.id ? `id: ${libQuery.id}` : `canonical url: ${libQuery.url}`
+        }${libQuery.version ? ` and version: ${libQuery.version}` : ''}`
+      );
+    }
+    return getAllDependentLibraries(libs[0] as Library);
+  });
+
+  const allDeps = await Promise.all(libraryGets);
+
+  results.push(...allDeps.flat());
+
+  return results;
 }

--- a/src/util/bundleUtils.ts
+++ b/src/util/bundleUtils.ts
@@ -86,7 +86,7 @@ export async function getAllDependentLibraries(lib: fhir4.Library): Promise<fhir
         ra.resource?.includes('Library') &&
         ra.resource !== 'http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1'
     ) // exclude modelinfo dependency
-    .map(ra => ra.resource as string); //TODO: may be able to improve this typing
+    .map(ra => ra.resource as string);
   // Obtain all libraries referenced in the related artifact, and recurse on their dependencies
   const libraryGets = depLibUrls.map(async url => {
     const libQuery = getQueryFromReference(url);

--- a/src/util/bundleUtils.ts
+++ b/src/util/bundleUtils.ts
@@ -58,7 +58,6 @@ export async function createMeasurePackageBundle(measure: fhir4.Measure): Promis
  * @returns {Filter} mongo query to pass in to mongo controller to search for the referenced resource
  */
 function getQueryFromReference(reference: string): Filter<any> {
-  // References could be canonical or resourceType/id
   if (reference.includes('|')) {
     const [urlPart, versionPart] = reference.split('|');
     return { url: urlPart, version: versionPart };
@@ -71,7 +70,7 @@ function getQueryFromReference(reference: string): Filter<any> {
  * Iterate through relatedArtifact of library and return list of all dependent libraries used
  */
 async function getAllDependentLibraries(lib: Library): Promise<Library[]> {
-  logger.debug(`Retrieving all dependent libraries for library: ${lib.id}`);
+  logger.info(`Retrieving all dependent libraries for library: ${lib.id}`);
   const results = [lib];
 
   // If the library has no dependencies, we are done

--- a/src/util/validationUtils.ts
+++ b/src/util/validationUtils.ts
@@ -13,3 +13,20 @@ export function validateSearchParams(query: RequestQuery) {
     throw new BadRequestError(`Parameters ${invalidParams.join(', ')} are not valid for search`);
   }
 }
+/*
+ * Gathers parameters from both the query and the FHIR parameter request body resource
+ */
+export function gatherParams(query: Record<string, any>, parameters?: fhir4.Parameters) {
+  const params = { ...query };
+
+  if (parameters?.parameter) {
+    parameters.parameter.reduce((acc, e) => {
+      if (!e.resource) {
+        // Currently value types needed by $package (add others as needed)
+        acc[e.name] = e.valueUrl || e.valueString || e.valueInteger || e.valueCanonical || e.valueBoolean;
+      }
+      return acc;
+    }, params);
+  }
+  return params;
+}

--- a/src/util/validationUtils.ts
+++ b/src/util/validationUtils.ts
@@ -17,16 +17,21 @@ export function validateSearchParams(query: RequestQuery) {
  * Gathers parameters from both the query and the FHIR parameter request body resource
  */
 export function gatherParams(query: Record<string, any>, parameters?: fhir4.Parameters) {
-  const params = { ...query };
+  const gatheredParams = { ...query };
 
   if (parameters?.parameter) {
-    parameters.parameter.reduce((acc, e) => {
-      if (!e.resource) {
+    parameters.parameter.reduce((params, bodyParam) => {
+      if (!bodyParam.resource) {
         // Currently value types needed by $package (add others as needed)
-        acc[e.name] = e.valueUrl || e.valueString || e.valueInteger || e.valueCanonical || e.valueBoolean;
+        params[bodyParam.name] =
+          bodyParam.valueUrl ||
+          bodyParam.valueString ||
+          bodyParam.valueInteger ||
+          bodyParam.valueCanonical ||
+          bodyParam.valueBoolean;
       }
-      return acc;
-    }, params);
+      return params;
+    }, gatheredParams);
   }
-  return params;
+  return gatheredParams;
 }

--- a/src/util/validationUtils.ts
+++ b/src/util/validationUtils.ts
@@ -13,17 +13,18 @@ export function validateSearchParams(query: RequestQuery) {
     throw new BadRequestError(`Parameters ${invalidParams.join(', ')} are not valid for search`);
   }
 }
+
 /*
  * Gathers parameters from both the query and the FHIR parameter request body resource
  */
-export function gatherParams(query: Record<string, any>, parameters?: fhir4.Parameters) {
-  const gatheredParams = { ...query };
+export function gatherParams(query: RequestQuery, parameters?: fhir4.Parameters) {
+  const gatheredParams: Record<string, any> = { ...query };
 
   if (parameters?.parameter) {
     parameters.parameter.reduce((params, bodyParam) => {
       if (!bodyParam.resource) {
         // Currently value types needed by $package (add others as needed)
-        params[bodyParam.name] =
+        params[bodyParam.name as string] =
           bodyParam.valueUrl ||
           bodyParam.valueString ||
           bodyParam.valueInteger ||

--- a/test/services/LibraryService.test.ts
+++ b/test/services/LibraryService.test.ts
@@ -45,7 +45,7 @@ describe('LibraryService', () => {
         .then(response => {
           expect(response.body.issue[0].code).toEqual('ResourceNotFound');
           expect(response.body.issue[0].details.text).toEqual(
-            `No resource found in collection: Library, with: id invalidID`
+            `No resource found in collection: Library, with id: invalidID`
           );
         });
     });

--- a/test/services/MeasureService.test.ts
+++ b/test/services/MeasureService.test.ts
@@ -81,7 +81,7 @@ describe('MeasureService', () => {
         .then(response => {
           expect(response.body.issue[0].code).toEqual('ResourceNotFound');
           expect(response.body.issue[0].details.text).toEqual(
-            `No resource found in collection: Measure, with: id invalidID`
+            `No resource found in collection: Measure, with id: invalidID`
           );
         });
     });
@@ -181,7 +181,7 @@ describe('MeasureService', () => {
         .then(response => {
           expect(response.body.issue[0].code).toEqual('ResourceNotFound');
           expect(response.body.issue[0].details.text).toEqual(
-            'No resource found in collection: Measure, with: id: invalid and url: invalid'
+            'No resource found in collection: Measure, with id: invalid and url: invalid'
           );
         });
     });

--- a/test/services/MeasureService.test.ts
+++ b/test/services/MeasureService.test.ts
@@ -5,12 +5,13 @@ import supertest from 'supertest';
 
 let server: Server;
 
-const MEASURE: fhir4.Measure = { resourceType: 'Measure', id: 'test', status: 'active' };
+const MEASURE: fhir4.Measure = { resourceType: 'Measure', id: 'test', status: 'active', version: 'searchable' };
 const MEASURE_WITH_URL: fhir4.Measure = {
   resourceType: 'Measure',
   id: 'testWithUrl',
   status: 'active',
-  url: 'http://example.com'
+  url: 'http://example.com',
+  version: 'searchable'
 };
 const MEASURE_WITH_ROOT_LIB: fhir4.Measure = {
   resourceType: 'Measure',
@@ -102,7 +103,7 @@ describe('MeasureService', () => {
     it('returns 200 and correct searchset bundle when query matches multiple resources', async () => {
       await supertest(server.app)
         .get('/4_0_1/Measure')
-        .query({ status: 'active' })
+        .query({ status: 'active', version: 'searchable' })
         .set('Accept', 'application/json+fhir')
         .expect(200)
         .then(response => {

--- a/test/util/bundleUtils.test.ts
+++ b/test/util/bundleUtils.test.ts
@@ -110,7 +110,6 @@ describe('bundleUtils', () => {
       try {
         await createMeasurePackageBundle(MEASURE_WITH_MISSING_LIBRARY);
       } catch (e: any) {
-        console.log(e);
         expect(e.statusCode).toEqual(404);
         expect(e.issue[0].details.text).toEqual(
           `Could not find Library http://example.com/MissingLibrary referenced by Measure MeasureMissingLib`
@@ -123,7 +122,6 @@ describe('bundleUtils', () => {
       try {
         await createMeasurePackageBundle(MEASURE_WITH_NO_LIBRARY);
       } catch (e: any) {
-        console.log(e);
         expect(e.statusCode).toEqual(400);
         expect(e.issue[0].details.text).toEqual('Uploaded measure: MeasureNoLib does not reference a Library');
       }

--- a/test/util/bundleUtils.test.ts
+++ b/test/util/bundleUtils.test.ts
@@ -1,0 +1,147 @@
+import {
+  createMeasurePackageBundle,
+  getAllDependentLibraries,
+  getQueryFromReference
+} from '../../src/util/bundleUtils';
+import { cleanUpTestDatabase, setupTestDatabase } from '../utils';
+
+const LIB_WITH_NO_DEPS: fhir4.Library = {
+  id: 'LibWithNoDeps',
+  url: 'http://example.com/LibraryWithNoDeps',
+  resourceType: 'Library',
+  status: 'draft',
+  type: { coding: [{ code: 'logic-library' }] }
+};
+
+const LIB_WITH_DEPS: fhir4.Library = {
+  id: 'LibraryWithDeps',
+  url: 'http://example.com/LibraryWithDeps',
+  resourceType: 'Library',
+  status: 'draft',
+  type: { coding: [{ code: 'logic-library' }] },
+  relatedArtifact: [
+    {
+      type: 'depends-on',
+      resource: 'http://example.com/LibraryWithNoDeps'
+    }
+  ]
+};
+
+const LIB_WITH_MISSING_DEPS: fhir4.Library = {
+  id: 'LibraryWithMissingDeps',
+  resourceType: 'Library',
+  status: 'draft',
+  type: { coding: [{ code: 'logic-library' }] },
+  relatedArtifact: [
+    {
+      type: 'depends-on',
+      resource: 'http://example.com/MissingLibrary'
+    }
+  ]
+};
+
+const MEASURE_WITH_MISSING_LIBRARY: fhir4.Measure = {
+  resourceType: 'Measure',
+  id: 'MeasureMissingLib',
+  status: 'draft',
+  library: ['http://example.com/MissingLibrary']
+};
+
+const MEASURE_WITH_NO_LIBRARY: fhir4.Measure = {
+  resourceType: 'Measure',
+  id: 'MeasureNoLib',
+  status: 'draft',
+  library: []
+};
+
+const MEASURE_WITH_LIBRARY: fhir4.Measure = {
+  resourceType: 'Measure',
+  id: 'MeasureWithLib',
+  status: 'draft',
+  library: ['http://example.com/LibraryWithDeps']
+};
+
+describe('bundleUtils', () => {
+  beforeAll(() => {
+    return setupTestDatabase([LIB_WITH_DEPS, LIB_WITH_NO_DEPS, LIB_WITH_MISSING_DEPS]);
+  });
+
+  describe('Testing getAllDependentLibraries()', () => {
+    it('returns just the lib when no relatedArtifacts present', async () => {
+      expect(await getAllDependentLibraries(LIB_WITH_NO_DEPS)).toEqual([LIB_WITH_NO_DEPS]);
+    });
+
+    it('returns lib and dependent libs when both exist', async () => {
+      expect(await getAllDependentLibraries(LIB_WITH_DEPS)).toEqual(
+        expect.arrayContaining([LIB_WITH_DEPS, LIB_WITH_NO_DEPS])
+      );
+    });
+
+    it('throws 404 error when dependent lib is missing', async () => {
+      expect.assertions(2);
+      try {
+        await getAllDependentLibraries(LIB_WITH_MISSING_DEPS);
+      } catch (e: any) {
+        expect(e.statusCode).toEqual(404);
+        expect(e.issue[0].details.text).toEqual(
+          'Failed to find dependent library with canonical url: http://example.com/MissingLibrary'
+        );
+      }
+    });
+  });
+
+  describe('getQueryFromReference', () => {
+    it('splits reference into url and version on | operator', () => {
+      expect(getQueryFromReference('http://example.com/Measure|Version')).toEqual({
+        url: 'http://example.com/Measure',
+        version: 'Version'
+      });
+    });
+    it('returns just url when no | operator', () => {
+      expect(getQueryFromReference('http://example.com/Measure')).toEqual({
+        url: 'http://example.com/Measure'
+      });
+    });
+  });
+
+  describe('createMeasurePackageBundle', () => {
+    it('throws a 404 error when dependent Library does not exist', async () => {
+      expect.assertions(2);
+      try {
+        await createMeasurePackageBundle(MEASURE_WITH_MISSING_LIBRARY);
+      } catch (e: any) {
+        console.log(e);
+        expect(e.statusCode).toEqual(404);
+        expect(e.issue[0].details.text).toEqual(
+          `Could not find Library http://example.com/MissingLibrary referenced by Measure MeasureMissingLib`
+        );
+      }
+    });
+
+    it('throws a 400 error when uploaded measure does not reference a library', async () => {
+      expect.assertions(2);
+      try {
+        await createMeasurePackageBundle(MEASURE_WITH_NO_LIBRARY);
+      } catch (e: any) {
+        console.log(e);
+        expect(e.statusCode).toEqual(400);
+        expect(e.issue[0].details.text).toEqual('Uploaded measure: MeasureNoLib does not reference a Library');
+      }
+    });
+
+    it('returns a bundle including a Measure and all dependent Libraries on valid input', async () => {
+      const bundle = await createMeasurePackageBundle(MEASURE_WITH_LIBRARY);
+      expect(bundle.resourceType).toEqual('Bundle');
+      expect(bundle.entry).toHaveLength(3);
+      expect(bundle.entry).toEqual(
+        expect.arrayContaining([
+          { resource: MEASURE_WITH_LIBRARY },
+          { resource: LIB_WITH_DEPS },
+          { resource: LIB_WITH_NO_DEPS }
+        ])
+      );
+    });
+  });
+
+  afterAll(cleanUpTestDatabase);
+});

--- a/test/util/validationUtils.test.ts
+++ b/test/util/validationUtils.test.ts
@@ -30,7 +30,7 @@ describe('validateSearchParams', () => {
         issue: [
           expect.objectContaining({
             details: {
-              text: 'Parameters invalid, alsoInvalid are not valid for search'
+              text: 'Parameters invalid are not valid for search'
             }
           })
         ]


### PR DESCRIPTION
# Summary
Creates the `/4_0_1/Measure/$package` endpoint which bundles a Measure with all its Libraries and dependent Libraries recursively, as outlined in the [docs](https://build.fhir.org/ig/HL7/cqf-measures/OperationDefinition-Measure-package.html )

## New behavior
 - 4 new endpoints:
 - `GET 4_0_1/Measure/$package`
 - `GET 4_0_1/Measure/<id>/$package`
 - `POST 4_0_1/Measure/$package`
 - `POST 4_0_1/Measure/<id>/$package`
 - Wowza new `db:loadBundle` script!

## Code changes
 - Added new endpoints in `serverConfig`
 - Created `db:loadBundle` script
 - lots n' lots of testing

# Testing guidance
 - `npm run check`
 - `git clone https://github.com/cqframework/ecqm-content-r4-2021.git`
 - `npm run db:reset`
 - ```npm run db:loadBundle "ecqm-content-r4-2021/bundles/measure/ColorectalCancerScreeningsFHIR/ColorectalCancerScreeningsFHIR-bundle.json"```
 - `npm start`
 - Run through the included Insomnia requests and make sure all outcomes are as expected!
 - For all passing requests, we expect the Bundle to include the Measure itself as well as 9 Library resources. The data will be too large for Insomnia to show it by default so you'll need to just click show anyway. The expected returned libraries are: 
 - `ColorectalCancerScreeningsFHIR`
 - `FHIRHelpers`
 - `SupplementalDataElementsFHIR4`
 - `MATGlobalCommonFunctionsFHIR4`
 - `AdultOutpatientEncountersFHIR4`
 - `HospiceFHIR4`
 - `AdvancedIllnessandFrailtyExclusionECQMFHIR4`
 - `CumulativeMedicationDurationFHIR4`
 - `PalliativeCareFHIR`
 [Measure-$package-testing.json.zip](https://github.com/projecttacoma/measure-repository-service/files/10281840/Measure-.package-testing.json.zip)

