### PR TITLE
Library $package 

### DIFF
--- a/src/config/serverConfig.ts
+++ b/src/config/serverConfig.ts
@@ -35,7 +35,33 @@ export const serverConfig: ServerConfig = {
     },
     Library: {
       service: new LibraryService(),
-      versions: [constants.VERSIONS['4_0_1']]
+      versions: [constants.VERSIONS['4_0_1']],
+      operation: [
+        {
+          name: 'package',
+          route: '/$package',
+          method: 'GET',
+          reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Library-package'
+        },
+        {
+          name: 'package',
+          route: '/$package',
+          method: 'POST',
+          reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Library-package'
+        },
+        {
+          name: 'package',
+          route: '/:id/$package',
+          method: 'GET',
+          reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Library-package'
+        },
+        {
+          name: 'package',
+          route: '/:id/$package',
+          method: 'POST',
+          reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Library-package'
+        }
+      ]
     }
   }
 };

--- a/src/services/LibraryService.ts
+++ b/src/services/LibraryService.ts
@@ -45,7 +45,7 @@ export class LibraryService implements Service<fhir4.Library> {
    * result of sending a POST or GET request to:
    * {BASE_URL}/4_0_1/Library/$package or {BASE_URL}/4_0_1/Library/:id/$package
    * creates a bundle of the library (specified by parameters) and all dependent libraries
-   * requires parameters id and/or url, but also supports version as supplemental (optional)
+   * requires parameters id, url, and/or identifier, but also supports version as supplemental (optional)
    */
   async package(args: RequestArgs, { req }: RequestCtx) {
     logger.info(`${req.method} ${req.path}`);
@@ -57,10 +57,9 @@ export class LibraryService implements Service<fhir4.Library> {
     const identifier = params.identifier;
 
     if (!id && !url && !identifier) {
-      throw new BadRequestError('Must provide identifying information via either id or url parameters');
+      throw new BadRequestError('Must provide identifying information via either id, url, or identifier parameters');
     }
 
-    // query construction
     const query: Filter<any> = {};
     if (id) query.id = id;
     if (url) query.url = url;

--- a/src/services/LibraryService.ts
+++ b/src/services/LibraryService.ts
@@ -54,8 +54,9 @@ export class LibraryService implements Service<fhir4.Library> {
     const id = args.id || params.id;
     const url = params.url;
     const version = params.version;
+    const identifier = params.identifier;
 
-    if (!id && !url) {
+    if (!id && !url && !identifier) {
       throw new BadRequestError('Must provide identifying information via either id or url parameters');
     }
 
@@ -64,7 +65,10 @@ export class LibraryService implements Service<fhir4.Library> {
     if (id) query.id = id;
     if (url) query.url = url;
     if (version) query.version = version;
-    const library = await findResourcesWithQuery<fhir4.Library>(query, 'Library');
+    if (identifier) query.identifier = identifier;
+
+    const parsedQuery = getMongoQueryFromRequest(query);
+    const library = await findResourcesWithQuery<fhir4.Library>(parsedQuery, 'Library');
     if (!library || !(library.length > 0)) {
       throw new ResourceNotFoundError(
         `No resource found in collection: Library, with ${Object.keys(query)

--- a/src/services/MeasureService.ts
+++ b/src/services/MeasureService.ts
@@ -57,10 +57,9 @@ export class MeasureService implements Service<fhir4.Measure> {
     const identifier = params.identifier;
 
     if (!id && !url && !identifier) {
-      throw new BadRequestError('Must provide identifying information via either id or url parameters');
+      throw new BadRequestError('Must provide identifying information via either id, url, or identifier parameters');
     }
 
-    // query construction
     const query: Filter<any> = {};
     if (id) query.id = id;
     if (url) query.url = url;

--- a/src/services/MeasureService.ts
+++ b/src/services/MeasureService.ts
@@ -54,8 +54,9 @@ export class MeasureService implements Service<fhir4.Measure> {
     const id = args.id || params.id;
     const url = params.url;
     const version = params.version;
+    const identifier = params.identifier;
 
-    if (!id && !url) {
+    if (!id && !url && !identifier) {
       throw new BadRequestError('Must provide identifying information via either id or url parameters');
     }
 
@@ -64,7 +65,10 @@ export class MeasureService implements Service<fhir4.Measure> {
     if (id) query.id = id;
     if (url) query.url = url;
     if (version) query.version = version;
-    const measure = await findResourcesWithQuery<fhir4.Measure>(query, 'Measure');
+    if (identifier) query.identifier = identifier;
+
+    const parsedQuery = getMongoQueryFromRequest(query);
+    const measure = await findResourcesWithQuery<fhir4.Measure>(parsedQuery, 'Measure');
     if (!measure || !(measure.length > 0)) {
       throw new ResourceNotFoundError(
         `No resource found in collection: Measure, with ${Object.keys(query)

--- a/src/util/bundleUtils.ts
+++ b/src/util/bundleUtils.ts
@@ -37,7 +37,7 @@ export async function createMeasurePackageBundle(measure: fhir4.Measure): Promis
     const mainLib = libs[0];
 
     const result = await createDepLibraryBundle(mainLib);
-    result.entry?.push({ resource: measure });
+    result.entry?.unshift({ resource: measure });
 
     return result;
   } else {

--- a/src/util/bundleUtils.ts
+++ b/src/util/bundleUtils.ts
@@ -30,7 +30,7 @@ export async function createMeasurePackageBundle(measure: fhir4.Measure): Promis
   if (measure.library && measure.library.length > 0) {
     const [mainLibraryRef] = measure.library;
     const mainLibQuery = getQueryFromReference(mainLibraryRef);
-    const libs = await findResourcesWithQuery(mainLibQuery, 'Library');
+    const libs = await findResourcesWithQuery<fhir4.Library>(mainLibQuery, 'Library');
     if (!libs || libs.length < 1) {
       throw new ResourceNotFoundError(`Could not find Library ${mainLibraryRef} referenced by Measure ${measure.id}`);
     }
@@ -60,8 +60,8 @@ export async function createLibraryPackageBundle(library: fhir4.Library): Promis
  * Takes in the main library from either Measure/$package or Library/$package
  * and returns a bundle of all the dependent libraries
  */
-export async function createDepLibraryBundle(mainLib: fhir4.FhirResource): Promise<fhir4.Bundle<fhir4.FhirResource>> {
-  const allLibsDups = await getAllDependentLibraries(mainLib as fhir4.Library);
+export async function createDepLibraryBundle(mainLib: fhir4.Library): Promise<fhir4.Bundle<fhir4.FhirResource>> {
+  const allLibsDups = await getAllDependentLibraries(mainLib);
   // de-dup by id using map
   const idMap = new Map(allLibsDups.map(lib => [lib.id, lib]));
   const allLibs = Array.from(idMap.values());

--- a/src/util/queryUtils.ts
+++ b/src/util/queryUtils.ts
@@ -18,7 +18,7 @@ export function getMongoQueryFromRequest(query: RequestQuery): Filter<any> {
       // For string arguments in query they may match just the start of a string and are case insensitive
       mf[key] = { $regex: `^${query[key]}`, $options: 'i' };
     } else if (key === 'identifier') {
-      // Identifier can check against the identifier.code, identifier.value, or both on a resource
+      // Identifier can check against the identifier.system, identifier.value, or both on a resource
       const iden = query.identifier as string;
       const splitIden = iden.split('|');
       if (splitIden.length === 1) {

--- a/test/services/LibraryService.test.ts
+++ b/test/services/LibraryService.test.ts
@@ -115,7 +115,7 @@ describe('LibraryService', () => {
         });
     });
 
-    it('returns a Bundle including the Library, and when the Library has no dependencies and id passed through body', async () => {
+    it('returns a Bundle including the Library when the Library has no dependencies and id passed through body', async () => {
       await supertest(server.app)
         .post('/4_0_1/Library/$package')
         .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testLibraryWithNoDeps' }] })
@@ -128,7 +128,7 @@ describe('LibraryService', () => {
         });
     });
 
-    it('returns a Bundle including the Library, and when the Library has dependencies and id passed through args', async () => {
+    it('returns a Bundle including the Library and its dependent libraries when the Library has dependencies and id passed through args', async () => {
       await supertest(server.app)
         .get('/4_0_1/Library/testLibraryWithDeps/$package')
         .expect(200)
@@ -142,7 +142,7 @@ describe('LibraryService', () => {
         });
     });
 
-    it('returns a Bundle including the Library, and when the Library has dependencies and id passed through body', async () => {
+    it('returns a Bundle including the Library and its dependent libraries when the Library has dependencies and id passed through body', async () => {
       await supertest(server.app)
         .post('/4_0_1/Library/$package')
         .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testLibraryWithDeps' }] })

--- a/test/services/LibraryService.test.ts
+++ b/test/services/LibraryService.test.ts
@@ -312,7 +312,7 @@ describe('LibraryService', () => {
         .then(response => {
           expect(response.body.issue[0].code).toEqual('BadRequest');
           expect(response.body.issue[0].details.text).toEqual(
-            'Must provide identifying information via either id or url parameters'
+            'Must provide identifying information via either id, url, or identifier parameters'
           );
         });
     });

--- a/test/services/LibraryService.test.ts
+++ b/test/services/LibraryService.test.ts
@@ -5,13 +5,6 @@ import supertest from 'supertest';
 
 let server: Server;
 
-const LIBRARY: fhir4.Library = {
-  resourceType: 'Library',
-  type: { coding: [{ code: 'logic-library' }] },
-  id: 'test',
-  status: 'active'
-};
-
 const LIBRARY_WITH_URL: fhir4.Library = {
   resourceType: 'Library',
   type: { coding: [{ code: 'logic-library' }] },
@@ -23,7 +16,7 @@ const LIBRARY_WITH_URL: fhir4.Library = {
 const LIBRARY_WITH_NO_DEPS: fhir4.Library = {
   resourceType: 'Library',
   id: 'testLibraryWithNoDeps',
-  status: 'draft',
+  status: 'active',
   url: 'http://example.com/testLibrary',
   type: { coding: [{ code: 'logic-library' }] }
 };
@@ -45,17 +38,17 @@ const LIBRARY_WITH_DEPS: fhir4.Library = {
 describe('LibraryService', () => {
   beforeAll(() => {
     server = initialize(serverConfig);
-    return setupTestDatabase([LIBRARY, LIBRARY_WITH_URL, LIBRARY_WITH_NO_DEPS, LIBRARY_WITH_DEPS]);
+    return setupTestDatabase([LIBRARY_WITH_URL, LIBRARY_WITH_NO_DEPS, LIBRARY_WITH_DEPS]);
   });
 
   describe('searchById', () => {
     it('returns 200 when passed correct headers and the id is in database', async () => {
       await supertest(server.app)
-        .get('/4_0_1/Library/test')
+        .get('/4_0_1/Library/testLibraryWithNoDeps')
         .set('Accept', 'application/json+fhir')
         .expect(200)
         .then(response => {
-          expect(response.body.id).toEqual(LIBRARY.id);
+          expect(response.body.id).toEqual(LIBRARY_WITH_NO_DEPS.id);
         });
     });
 
@@ -99,7 +92,7 @@ describe('LibraryService', () => {
           expect(response.body.entry).toEqual(
             expect.arrayContaining([
               expect.objectContaining<fhir4.BundleEntry>({
-                resource: LIBRARY
+                resource: LIBRARY_WITH_NO_DEPS
               }),
               expect.objectContaining<fhir4.BundleEntry>({
                 resource: LIBRARY_WITH_URL

--- a/test/services/MeasureService.test.ts
+++ b/test/services/MeasureService.test.ts
@@ -193,6 +193,26 @@ describe('MeasureService', () => {
         });
     });
 
+    it('throws a 404 error when both the Measure id and url are specified but one of them is invalid', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Measure/$package')
+        .send({
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'id', valueString: 'testWithUrl' },
+            { name: 'url', valueUrl: 'invalid' }
+          ]
+        })
+        .set('content-type', 'application/fhir+json')
+        .expect(404)
+        .then(response => {
+          expect(response.body.issue[0].code).toEqual('ResourceNotFound');
+          expect(response.body.issue[0].details.text).toEqual(
+            'No resource found in collection: Measure, with id: testWithUrl and url: invalid'
+          );
+        });
+    });
+
     it('throws a 400 error when no url or id included in request', async () => {
       await supertest(server.app)
         .post('/4_0_1/Measure/$package')

--- a/test/services/MeasureService.test.ts
+++ b/test/services/MeasureService.test.ts
@@ -15,6 +15,32 @@ const MEASURE_WITH_URL: fhir4.Measure = {
   version: 'searchable'
 };
 
+const MEASURE_WITH_IDENTIFIER_VALUE_ROOT_LIB: fhir4.Measure = {
+  resourceType: 'Measure',
+  identifier: [{ value: 'measureWithIdentifierValueRootLib' }],
+  library: ['http://example.com/testLibrary'],
+  status: 'active'
+};
+
+const MEASURE_WITH_IDENTIFIER_SYSTEM_ROOT_LIB: fhir4.Measure = {
+  resourceType: 'Measure',
+  identifier: [{ system: 'http://example.com/measureWithIdentifierSystemRootLib' }],
+  library: ['http://example.com/testLibrary'],
+  status: 'active'
+};
+
+const MEASURE_WITH_IDENTIFIER_SYSTEM_AND_VALUE_ROOT_LIB: fhir4.Measure = {
+  resourceType: 'Measure',
+  identifier: [
+    {
+      value: 'measureWithIdentifierSystemAndValueRootLib',
+      system: 'http://example.com/measureWithIdentifierSystemAndValueRootLib'
+    }
+  ],
+  library: ['http://example.com/testLibrary'],
+  status: 'active'
+};
+
 const MEASURE_WITH_ROOT_LIB: fhir4.Measure = {
   resourceType: 'Measure',
   id: 'testWithRootLib',
@@ -62,7 +88,10 @@ describe('MeasureService', () => {
       MEASURE_WITH_ROOT_LIB,
       MEASURE_WITH_ROOT_LIB_AND_DEPS,
       LIBRARY_WITH_NO_DEPS,
-      LIBRARY_WITH_DEPS
+      LIBRARY_WITH_DEPS,
+      MEASURE_WITH_IDENTIFIER_VALUE_ROOT_LIB,
+      MEASURE_WITH_IDENTIFIER_SYSTEM_AND_VALUE_ROOT_LIB,
+      MEASURE_WITH_IDENTIFIER_SYSTEM_ROOT_LIB
     ]);
   });
 
@@ -145,7 +174,7 @@ describe('MeasureService', () => {
     it('returns a Bundle including the root lib and Measure when root lib has no dependencies and id passed through body', async () => {
       await supertest(server.app)
         .post('/4_0_1/Measure/$package')
-        .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testWithRootLib' }] })
+        .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueUrl: 'testWithRootLib' }] })
         .set('content-type', 'application/fhir+json')
         .expect(200)
         .then(response => {
@@ -188,6 +217,75 @@ describe('MeasureService', () => {
               { resource: LIBRARY_WITH_DEPS },
               { resource: LIBRARY_WITH_NO_DEPS },
               { resource: MEASURE_WITH_ROOT_LIB_AND_DEPS }
+            ])
+          );
+        });
+    });
+
+    it('returns a Bundle including the root lib and Measure when root lib has no dependencies and identifier with just identifier.value passed through body', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Measure/$package')
+        .send({
+          resourceType: 'Parameters',
+          parameter: [{ name: 'identifier', valueString: 'measureWithIdentifierValueRootLib' }]
+        })
+        .set('content-type', 'application/fhir+json')
+        .expect(200)
+        .then(response => {
+          expect(response.body.resourceType).toEqual('Bundle');
+          expect(response.body.entry).toHaveLength(2);
+          expect(response.body.entry).toEqual(
+            expect.arrayContaining([
+              { resource: LIBRARY_WITH_NO_DEPS },
+              { resource: MEASURE_WITH_IDENTIFIER_VALUE_ROOT_LIB }
+            ])
+          );
+        });
+    });
+
+    it('returns a Bundle including the root lib and Measure when root lib has no dependencies and identifier with just identifier.system passed through body', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Measure/$package')
+        .send({
+          resourceType: 'Parameters',
+          parameter: [{ name: 'identifier', valueString: 'http://example.com/measureWithIdentifierSystemRootLib|' }]
+        })
+        .set('content-type', 'application/fhir+json')
+        .expect(200)
+        .then(response => {
+          expect(response.body.resourceType).toEqual('Bundle');
+          expect(response.body.entry).toHaveLength(2);
+          expect(response.body.entry).toEqual(
+            expect.arrayContaining([
+              { resource: LIBRARY_WITH_NO_DEPS },
+              { resource: MEASURE_WITH_IDENTIFIER_SYSTEM_ROOT_LIB }
+            ])
+          );
+        });
+    });
+
+    it('returns a Bundle including the root lib and Measure when root lib has no dependencies and identifier with both identifier.system and identifier.value passed through body', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Measure/$package')
+        .send({
+          resourceType: 'Parameters',
+          parameter: [
+            {
+              name: 'identifier',
+              valueString:
+                'http://example.com/measureWithIdentifierSystemAndValueRootLib|measureWithIdentifierSystemAndValueRootLib'
+            }
+          ]
+        })
+        .set('content-type', 'application/fhir+json')
+        .expect(200)
+        .then(response => {
+          expect(response.body.resourceType).toEqual('Bundle');
+          expect(response.body.entry).toHaveLength(2);
+          expect(response.body.entry).toEqual(
+            expect.arrayContaining([
+              { resource: LIBRARY_WITH_NO_DEPS },
+              { resource: MEASURE_WITH_IDENTIFIER_SYSTEM_AND_VALUE_ROOT_LIB }
             ])
           );
         });

--- a/test/services/MeasureService.test.ts
+++ b/test/services/MeasureService.test.ts
@@ -142,7 +142,7 @@ describe('MeasureService', () => {
         });
     });
 
-    it('returns a Bundle including the root lib, Measure, and when root lib has no dependencies and id passed through body', async () => {
+    it('returns a Bundle including the root lib and Measure when root lib has no dependencies and id passed through body', async () => {
       await supertest(server.app)
         .post('/4_0_1/Measure/$package')
         .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testWithRootLib' }] })
@@ -157,7 +157,7 @@ describe('MeasureService', () => {
         });
     });
 
-    it('returns a Bundle including the root lib and Measure when root lib has dependencies and id passed through args', async () => {
+    it('returns a Bundle including the root lib, Measure and dependent libraries when root lib has dependencies and id passed through args', async () => {
       await supertest(server.app)
         .get('/4_0_1/Measure/testWithRootLibAndDeps/$package')
         .expect(200)
@@ -174,7 +174,7 @@ describe('MeasureService', () => {
         });
     });
 
-    it('returns a Bundle including the root lib, Measure, and when root lib has dependencies and id passed through body', async () => {
+    it('returns a Bundle including the root lib, Measure, and dependent libraries when root lib has dependencies and id passed through body', async () => {
       await supertest(server.app)
         .post('/4_0_1/Measure/$package')
         .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testWithRootLibAndDeps' }] })

--- a/test/services/MeasureService.test.ts
+++ b/test/services/MeasureService.test.ts
@@ -320,7 +320,7 @@ describe('MeasureService', () => {
         .then(response => {
           expect(response.body.issue[0].code).toEqual('BadRequest');
           expect(response.body.issue[0].details.text).toEqual(
-            'Must provide identifying information via either id or url parameters'
+            'Must provide identifying information via either id, url, or identifier parameters'
           );
         });
     });

--- a/test/util/bundleUtils.test.ts
+++ b/test/util/bundleUtils.test.ts
@@ -1,4 +1,6 @@
 import {
+  createDepLibraryBundle,
+  createLibraryPackageBundle,
   createMeasurePackageBundle,
   getAllDependentLibraries,
   getQueryFromReference
@@ -104,6 +106,24 @@ describe('bundleUtils', () => {
     });
   });
 
+  describe('createDepLibraryBundle', () => {
+    it('returns just the main lib when the main lib has no dependencies', async () => {
+      const libBundle = await createDepLibraryBundle(LIB_WITH_NO_DEPS);
+      expect(libBundle.resourceType).toEqual('Bundle');
+      expect(libBundle.entry).toHaveLength(1);
+      expect(libBundle.entry).toEqual(expect.arrayContaining([{ resource: LIB_WITH_NO_DEPS }]));
+    });
+
+    it('returns the main lib and its dependent libraries', async () => {
+      const libBundle = await createDepLibraryBundle(LIB_WITH_DEPS);
+      expect(libBundle.resourceType).toEqual('Bundle');
+      expect(libBundle.entry).toHaveLength(2);
+      expect(libBundle.entry).toEqual(
+        expect.arrayContaining([{ resource: LIB_WITH_DEPS }, { resource: LIB_WITH_NO_DEPS }])
+      );
+    });
+  });
+
   describe('createMeasurePackageBundle', () => {
     it('throws a 404 error when dependent Library does not exist', async () => {
       expect.assertions(2);
@@ -137,6 +157,17 @@ describe('bundleUtils', () => {
           { resource: LIB_WITH_DEPS },
           { resource: LIB_WITH_NO_DEPS }
         ])
+      );
+    });
+  });
+
+  describe('createLibraryPackageBundle', () => {
+    it('returns a bundle including a Library and all dependent Libraries on valid input', async () => {
+      const bundle = await createLibraryPackageBundle(LIB_WITH_DEPS);
+      expect(bundle.resourceType).toEqual('Bundle');
+      expect(bundle.entry).toHaveLength(2);
+      expect(bundle.entry).toEqual(
+        expect.arrayContaining([{ resource: LIB_WITH_DEPS }, { resource: LIB_WITH_NO_DEPS }])
       );
     });
   });


### PR DESCRIPTION
# Summary
Creates the `/4_0_1/Library/$package` endpoint which bundles a Library with all of its dependent libraries recursively, as outlined in the [docs](https://build.fhir.org/ig/HL7/cqf-measures/OperationDefinition-Library-package.html).

## New behavior
- 4 new endpoints:
- `GET 4_0_1/Library/$package`
- `GET 4_0_1/Library/<id>/$package`
- `POST 4_0_1/Library/$package`
- `POST 4_0_1/Library/<id>/$package`
- Additional testing for these endpoints as well as some for Measure/$package

## Code changes
- `src/config/serverConfig.ts` - added above endpoints
- `src/services/LibraryService.ts` - added `package` function which handles the above endpoints. It is similar to the `package` function in `MeasureService.ts`.
- `src/util/bundleUtils` - created a `createLibraryPackageBundle` function and refactored the reusable code in `createMeasurePackageBundle` into a new function called `createDepLibraryBundle` so that it can be used by both services.
- `test/services/LibraryService.test.ts` - added tests 
- `test/services/MeasureService.test.ts` - I noticed that one of the test descriptions was misleading so I changed it and then added two additional tests. Some of these tests may be redundant so let me know if some of these can be removed (same with tests in `LibraryService.test.ts`.
- `test/util/bundleUtils.test.ts` - added tests for `createLibraryPackageBundle` function and `createDepLibraryBundle` function.

# Testing guidance
_Inspired by Testing guidance by Nat/Lauren in the [Measure $package PR](https://github.com/projecttacoma/measure-repository-service/pull/5)_ 
- `npm run check`
- `git clone https://github.com/cqframework/ecqm-content-r4-2021.git`
- `npm run db:reset`
- `npm run db:loadBundle "ecqm-content-r4-2021/bundles/measure/ColorectalCancerScreeningsFHIR/ColorectalCancerScreeningsFHIR-bundle.json"`
- `npm start`
- Run through the included Insomnia requests and make sure all outcomes are as expected!
- For all passing requests, we expect the Bundle to include 9 Library resources. The data will be too large for Insomnia to show it by default so you'll need to just click show anyway. **NOTE:** this is the same outcome as the `Measure/$package` operation, but without the Measure.
- The expected returned libraries are:
- `ColorectalCancerScreeningsFHIR`
- `FHIRHelpers`
- `SupplementalDataElementsFHIR4`
- `MATGlobalCommonFunctionsFHIR4`
- `AdultOutpatientEncountersFHIR4`
- `HospiceFHIR4`
- `AdvancedIllnessFrailtyExclusionECQMFHIR4`
- `CumulativeMedicationDurationFHIR4`
- `PalliativeCareFHIR`

[Library-$package-testing.json.zip](https://github.com/projecttacoma/measure-repository-service/files/10322230/Library-.package-testing.json.zip)
