### PR TITLE
Update OperationOutcome issue codes

### DIFF
--- a/src/services/LibraryService.ts
+++ b/src/services/LibraryService.ts
@@ -57,7 +57,10 @@ export class LibraryService implements Service<fhir4.Library> {
     const identifier = params.identifier;
 
     if (!id && !url && !identifier) {
-      throw new BadRequestError('Must provide identifying information via either id, url, or identifier parameters');
+      throw new BadRequestError(
+        'Must provide identifying information via either id, url, or identifier parameters',
+        'required'
+      );
     }
 
     const query: Filter<any> = {};

--- a/src/services/LibraryService.ts
+++ b/src/services/LibraryService.ts
@@ -1,4 +1,4 @@
-import { loggers, RequestArgs, RequestCtx } from '@projecttacoma/node-fhir-server-core';
+import { loggers, RequestArgs, RequestCtx, constants } from '@projecttacoma/node-fhir-server-core';
 import { Filter } from 'mongodb';
 import { findResourceById, findResourcesWithQuery } from '../db/dbOperations';
 import { Service } from '../types/service';
@@ -59,7 +59,7 @@ export class LibraryService implements Service<fhir4.Library> {
     if (!id && !url && !identifier) {
       throw new BadRequestError(
         'Must provide identifying information via either id, url, or identifier parameters',
-        'required'
+        constants.ISSUE.CODE.REQUIRED
       );
     }
 

--- a/src/services/MeasureService.ts
+++ b/src/services/MeasureService.ts
@@ -1,4 +1,4 @@
-import { loggers, RequestArgs, RequestCtx } from '@projecttacoma/node-fhir-server-core';
+import { loggers, RequestArgs, RequestCtx, constants } from '@projecttacoma/node-fhir-server-core';
 import { Filter } from 'mongodb';
 import { findResourceById, findResourcesWithQuery } from '../db/dbOperations';
 import { Service } from '../types/service';
@@ -59,7 +59,7 @@ export class MeasureService implements Service<fhir4.Measure> {
     if (!id && !url && !identifier) {
       throw new BadRequestError(
         'Must provide identifying information via either id, url, or identifier parameters',
-        'required'
+        constants.ISSUE.CODE.REQUIRED
       );
     }
 

--- a/src/services/MeasureService.ts
+++ b/src/services/MeasureService.ts
@@ -57,7 +57,10 @@ export class MeasureService implements Service<fhir4.Measure> {
     const identifier = params.identifier;
 
     if (!id && !url && !identifier) {
-      throw new BadRequestError('Must provide identifying information via either id, url, or identifier parameters');
+      throw new BadRequestError(
+        'Must provide identifying information via either id, url, or identifier parameters',
+        'required'
+      );
     }
 
     const query: Filter<any> = {};

--- a/src/util/errorUtils.ts
+++ b/src/util/errorUtils.ts
@@ -1,4 +1,4 @@
-import { ServerError } from '@projecttacoma/node-fhir-server-core';
+import { ServerError, constants } from '@projecttacoma/node-fhir-server-core';
 
 /**
  * Child class of ServerError with custom options object
@@ -25,7 +25,7 @@ class CustomServerError extends ServerError {
  */
 export class ResourceNotFoundError extends CustomServerError {
   constructor(message: string) {
-    super(message, 404, 'not-found');
+    super(message, 404, constants.ISSUE.CODE.NOT_FOUND);
   }
 }
 
@@ -33,7 +33,7 @@ export class ResourceNotFoundError extends CustomServerError {
  * Error class that throws ServerError with status code 400 and code (defaults to 'invalid')
  */
 export class BadRequestError extends CustomServerError {
-  constructor(message: string, customCode = 'invalid') {
+  constructor(message: string, customCode: string = constants.ISSUE.CODE.INVALID) {
     super(message, 400, customCode);
   }
 }
@@ -43,6 +43,6 @@ export class BadRequestError extends CustomServerError {
  */
 export class NotImplementedError extends CustomServerError {
   constructor(message: string) {
-    super(message, 501, 'not-supported');
+    super(message, 501, constants.ISSUE.CODE.NOT_SUPPORTED);
   }
 }

--- a/src/util/errorUtils.ts
+++ b/src/util/errorUtils.ts
@@ -21,28 +21,28 @@ class CustomServerError extends ServerError {
 }
 
 /**
- * Error class that throws ServerError with status code 404 and code ResourceNotFound
+ * Error class that throws ServerError with status code 404 and code not-found
  */
 export class ResourceNotFoundError extends CustomServerError {
   constructor(message: string) {
-    super(message, 404, 'ResourceNotFound');
+    super(message, 404, 'not-found');
   }
 }
 
 /**
- * Error class that throws ServerError with status code 400 and code BadRequest
+ * Error class that throws ServerError with status code 400 and code (defaults to 'invalid')
  */
 export class BadRequestError extends CustomServerError {
-  constructor(message: string) {
-    super(message, 400, 'BadRequest');
+  constructor(message: string, customCode = 'invalid') {
+    super(message, 400, customCode);
   }
 }
 
 /**
- * Error class that throws ServerError with status code 501 and code NotImplemented
+ * Error class that throws ServerError with status code 501 and code not-supported
  */
 export class NotImplementedError extends CustomServerError {
   constructor(message: string) {
-    super(message, 501, 'NotImplemented');
+    super(message, 501, 'not-supported');
   }
 }

--- a/src/util/validationUtils.ts
+++ b/src/util/validationUtils.ts
@@ -1,4 +1,4 @@
-import { RequestQuery } from '@projecttacoma/node-fhir-server-core';
+import { RequestQuery, constants } from '@projecttacoma/node-fhir-server-core';
 import { BadRequestError } from './errorUtils';
 
 const UNIVERSAL_VALID_SEARCH_PARAMS = ['url', 'version', 'identifier', 'name', 'title', 'status', 'description'];
@@ -10,7 +10,10 @@ const UNIVERSAL_VALID_SEARCH_PARAMS = ['url', 'version', 'identifier', 'name', '
 export function validateSearchParams(query: RequestQuery) {
   const invalidParams = Object.keys(query).filter(param => !UNIVERSAL_VALID_SEARCH_PARAMS.includes(param));
   if (invalidParams.length > 0) {
-    throw new BadRequestError(`Parameters ${invalidParams.join(', ')} are not valid for search`, 'value');
+    throw new BadRequestError(
+      `Parameters ${invalidParams.join(', ')} are not valid for search`,
+      constants.ISSUE.CODE.VALUE
+    );
   }
 }
 

--- a/src/util/validationUtils.ts
+++ b/src/util/validationUtils.ts
@@ -10,7 +10,7 @@ const UNIVERSAL_VALID_SEARCH_PARAMS = ['url', 'version', 'identifier', 'name', '
 export function validateSearchParams(query: RequestQuery) {
   const invalidParams = Object.keys(query).filter(param => !UNIVERSAL_VALID_SEARCH_PARAMS.includes(param));
   if (invalidParams.length > 0) {
-    throw new BadRequestError(`Parameters ${invalidParams.join(', ')} are not valid for search`);
+    throw new BadRequestError(`Parameters ${invalidParams.join(', ')} are not valid for search`, 'value');
   }
 }
 

--- a/test/services/LibraryService.test.ts
+++ b/test/services/LibraryService.test.ts
@@ -119,7 +119,7 @@ describe('LibraryService', () => {
         .set('Accept', 'application/json+fhir')
         .expect(404)
         .then(response => {
-          expect(response.body.issue[0].code).toEqual('ResourceNotFound');
+          expect(response.body.issue[0].code).toEqual('not-found');
           expect(response.body.issue[0].details.text).toEqual(
             `No resource found in collection: Library, with id: invalidID`
           );
@@ -296,7 +296,7 @@ describe('LibraryService', () => {
         .set('content-type', 'application/fhir+json')
         .expect(400)
         .then(response => {
-          expect(response.body.issue[0].code).toEqual('BadRequest');
+          expect(response.body.issue[0].code).toEqual('invalid');
           expect(response.body.issue[0].details.text).toEqual(
             'Multiple resources found in collection: Library, with identifier: http://example.com/libraryWithSameSystem|. /Library/$package operation must specify a single Library'
           );
@@ -310,7 +310,7 @@ describe('LibraryService', () => {
         .set('content-type', 'application/fhir+json')
         .expect(400)
         .then(response => {
-          expect(response.body.issue[0].code).toEqual('BadRequest');
+          expect(response.body.issue[0].code).toEqual('required');
           expect(response.body.issue[0].details.text).toEqual(
             'Must provide identifying information via either id, url, or identifier parameters'
           );
@@ -330,7 +330,7 @@ describe('LibraryService', () => {
         .set('content-type', 'application/fhir+json')
         .expect(404)
         .then(response => {
-          expect(response.body.issue[0].code).toEqual('ResourceNotFound');
+          expect(response.body.issue[0].code).toEqual('not-found');
           expect(response.body.issue[0].details.text).toEqual(
             'No resource found in collection: Library, with id: testLibraryWithDeps and url: invalid'
           );
@@ -350,7 +350,7 @@ describe('LibraryService', () => {
         .set('content-type', 'application/fhir+json')
         .expect(404)
         .then(response => {
-          expect(response.body.issue[0].code).toEqual('ResourceNotFound');
+          expect(response.body.issue[0].code).toEqual('not-found');
           expect(response.body.issue[0].details.text).toEqual(
             'No resource found in collection: Library, with id: invalid and url: invalid'
           );

--- a/test/services/MeasureService.test.ts
+++ b/test/services/MeasureService.test.ts
@@ -112,7 +112,7 @@ describe('MeasureService', () => {
         .set('Accept', 'application/json+fhir')
         .expect(404)
         .then(response => {
-          expect(response.body.issue[0].code).toEqual('ResourceNotFound');
+          expect(response.body.issue[0].code).toEqual('not-found');
           expect(response.body.issue[0].details.text).toEqual(
             `No resource found in collection: Measure, with id: invalidID`
           );
@@ -304,7 +304,7 @@ describe('MeasureService', () => {
         .set('content-type', 'application/fhir+json')
         .expect(404)
         .then(response => {
-          expect(response.body.issue[0].code).toEqual('ResourceNotFound');
+          expect(response.body.issue[0].code).toEqual('not-found');
           expect(response.body.issue[0].details.text).toEqual(
             'No resource found in collection: Measure, with id: testWithUrl and url: invalid'
           );
@@ -318,7 +318,7 @@ describe('MeasureService', () => {
         .set('content-type', 'application/fhir+json')
         .expect(400)
         .then(response => {
-          expect(response.body.issue[0].code).toEqual('BadRequest');
+          expect(response.body.issue[0].code).toEqual('required');
           expect(response.body.issue[0].details.text).toEqual(
             'Must provide identifying information via either id, url, or identifier parameters'
           );
@@ -338,7 +338,7 @@ describe('MeasureService', () => {
         .set('content-type', 'application/fhir+json')
         .expect(404)
         .then(response => {
-          expect(response.body.issue[0].code).toEqual('ResourceNotFound');
+          expect(response.body.issue[0].code).toEqual('not-found');
           expect(response.body.issue[0].details.text).toEqual(
             'No resource found in collection: Measure, with id: invalid and url: invalid'
           );


### PR DESCRIPTION
# Summary
Updates the OperationOutcome `issue.code` for all thrown OperationOutcomes to be of type `IssueType`.

## New behavior
When an error is thrown from the server, the resulting OperationOutcome will have an `issue.code` that is a valid `IssueType` - see the [code system](https://www.hl7.org/fhir/codesystem-issue-type.html) for more information on what codes are considered valid.

## Code changes
* Updates to `errorUtils.ts` to change the `issue.code`s for the custom error classes. `ResourceNotFoundError` and `NotImplementedError` are pretty straightforward. Since `BadRequestError` is pretty broad, I decided to have the error default to `issue.code` ‘invalid’ (which is the “parent” of invalid codes). Throughout the code, if a more specific code made sense (ex. ‘required’ instead of ‘invalid’ if the request is missing a required element), I replaced ‘invalid’ with that code. Open to suggestions on this since these changes were made based on my own intuition — if it makes sense to just have all `BadRequestError`s be ‘invalid’ then that would also work.
* Updates to corresponding unit tests, comments, etc. 

# Testing guidance
* Run unit tests, as all tests containing an OperationOutcome check the value of the `issue.code`
* Try testing in the server - do something that would throw an OperationOutcome (ex. Send a GET request to a library that does not exist on the server) and check that the code is of type `IssueType`
