### PR TITLE
ValueSets and spec updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@
 PORT=3000
 HOST='localhost'
 DATABASE_URL='mongodb://localhost:27017/measure-repository'
+VSAC_API_KEY="<your-api-key>" # Add if you plan on using the `include-terminology` query param

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+VSAC_API_KEY="example-api-key"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 node_modules
 .env
 .DS_Store
+cache

--- a/package-lock.json
+++ b/package-lock.json
@@ -6461,9 +6461,10 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -13476,7 +13477,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "jsonfile": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "eslint": "^8.28.0",
         "eslint-config-prettier": "^8.5.0",
         "jest": "^29.3.1",
+        "nock": "^13.3.0",
         "nodemon": "^2.0.20",
         "prettier": "^2.8.0",
         "supertest": "^6.3.3",
@@ -6447,6 +6448,12 @@
       "version": "1.0.1",
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
+    },
     "node_modules/json5": {
       "version": "2.2.1",
       "dev": true,
@@ -7078,6 +7085,44 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/nock": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.0.tgz",
+      "integrity": "sha512-HHqYQ6mBeiMc+N038w8LkMpDCRquCHWeNmN3v6645P3NhN2+qXOBqvPqo7Rt1VyCMzKhJ733wZqw5B7cQVFNPg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.21",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
+    "node_modules/nock/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nock/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "dev": true,
@@ -7575,6 +7620,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/proxy-addr": {
@@ -13403,6 +13457,12 @@
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1"
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
+    },
     "json5": {
       "version": "2.2.1",
       "dev": true
@@ -13810,6 +13870,35 @@
     "nocache": {
       "version": "2.1.0"
     },
+    "nock": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.0.tgz",
+      "integrity": "sha512-HHqYQ6mBeiMc+N038w8LkMpDCRquCHWeNmN3v6645P3NhN2+qXOBqvPqo7Rt1VyCMzKhJ733wZqw5B7cQVFNPg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.21",
+        "propagate": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "node-int64": {
       "version": "0.4.0",
       "dev": true
@@ -14096,6 +14185,12 @@
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
       }
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
     },
     "proxy-addr": {
       "version": "2.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@projecttacoma/node-fhir-server-core": "^2.2.8",
         "dotenv": "^16.0.3",
-        "fqm-execution": "^1.0.3",
+        "fqm-execution": "^1.0.4",
         "mongodb": "^4.12.1",
         "uuid": "^9.0.0"
       },
@@ -4038,12 +4038,13 @@
       }
     },
     "node_modules/cql-execution": {
-      "version": "3.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.2.tgz",
-      "integrity": "sha512-rpBUkUotVAUfz73HGF+Vs1UItULuZcEGmAwHkPxCpWEUXXVKWL7Dc9vPbRu5lCteMovKSJDSZsK+jHqDd+iYhQ==",
+      "version": "3.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.3.tgz",
+      "integrity": "sha512-Mcr3vUilXfnz2qooyKzKZT3lexWTo/U7ktwt3DXnAFfsKfCYBe4zHyGv9ThRwW7OFMM/mr5LmM4szbm2StSfZw==",
       "dependencies": {
         "@lhncbc/ucum-lhc": "^4.1.3",
-        "luxon": "^1.25.0"
+        "immutable": "^4.1.0",
+        "luxon": "^1.28.1"
       }
     },
     "node_modules/create-require": {
@@ -5108,16 +5109,16 @@
       }
     },
     "node_modules/fqm-execution": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-1.0.3.tgz",
-      "integrity": "sha512-oCpLogf7Kq8i+xHTEVyhxjD1rnCnbvShr6zFx+xW1oDaBdeH0aAGHvkY856vETBqJyoAT32jjoF7Hvpsf5ZLgg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-1.0.4.tgz",
+      "integrity": "sha512-pOg0bvTCsdb4Rnhl7++9yhy+wmEgcaEa8vsUV76xdzk8d8r4PE9MQ08VXjWXdzA9Dv0+RpDGUTqVqpD2Z93AVw==",
       "dependencies": {
         "@types/fhir": "0.0.34",
         "atob": "^2.1.2",
         "axios": "^0.21.1",
         "commander": "^6.1.0",
         "cql-exec-fhir": "^2.1.3",
-        "cql-execution": "^3.0.0-beta.2",
+        "cql-execution": "^3.0.0-beta.3",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
@@ -5563,6 +5564,11 @@
       "version": "1.0.1",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/immutable": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.2.tgz",
+      "integrity": "sha512-fTMKDwtbvO5tldky9QZ2fMX7slR0mYpY5nbnFWYp0fOzDhHqhgIw9KoYgxLWsoNTS9ZHGauHj18DTyEw6BK3Og=="
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -11917,12 +11923,13 @@
       }
     },
     "cql-execution": {
-      "version": "3.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.2.tgz",
-      "integrity": "sha512-rpBUkUotVAUfz73HGF+Vs1UItULuZcEGmAwHkPxCpWEUXXVKWL7Dc9vPbRu5lCteMovKSJDSZsK+jHqDd+iYhQ==",
+      "version": "3.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.3.tgz",
+      "integrity": "sha512-Mcr3vUilXfnz2qooyKzKZT3lexWTo/U7ktwt3DXnAFfsKfCYBe4zHyGv9ThRwW7OFMM/mr5LmM4szbm2StSfZw==",
       "requires": {
         "@lhncbc/ucum-lhc": "^4.1.3",
-        "luxon": "^1.25.0"
+        "immutable": "^4.1.0",
+        "luxon": "^1.28.1"
       }
     },
     "create-require": {
@@ -12595,16 +12602,16 @@
       "version": "0.2.0"
     },
     "fqm-execution": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-1.0.3.tgz",
-      "integrity": "sha512-oCpLogf7Kq8i+xHTEVyhxjD1rnCnbvShr6zFx+xW1oDaBdeH0aAGHvkY856vETBqJyoAT32jjoF7Hvpsf5ZLgg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-1.0.4.tgz",
+      "integrity": "sha512-pOg0bvTCsdb4Rnhl7++9yhy+wmEgcaEa8vsUV76xdzk8d8r4PE9MQ08VXjWXdzA9Dv0+RpDGUTqVqpD2Z93AVw==",
       "requires": {
         "@types/fhir": "0.0.34",
         "atob": "^2.1.2",
         "axios": "^0.21.1",
         "commander": "^6.1.0",
         "cql-exec-fhir": "^2.1.3",
-        "cql-execution": "^3.0.0-beta.2",
+        "cql-execution": "^3.0.0-beta.3",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
@@ -12868,6 +12875,11 @@
     "ignore-by-default": {
       "version": "1.0.1",
       "dev": true
+    },
+    "immutable": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.2.tgz",
+      "integrity": "sha512-fTMKDwtbvO5tldky9QZ2fMX7slR0mYpY5nbnFWYp0fOzDhHqhgIw9KoYgxLWsoNTS9ZHGauHj18DTyEw6BK3Og=="
     },
     "import-fresh": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@projecttacoma/node-fhir-server-core": "^2.2.8",
     "dotenv": "^16.0.3",
-    "fqm-execution": "^1.0.3",
+    "fqm-execution": "^1.0.4",
     "mongodb": "^4.12.1",
     "uuid": "^9.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint": "^8.28.0",
     "eslint-config-prettier": "^8.5.0",
     "jest": "^29.3.1",
+    "nock": "^13.3.0",
     "nodemon": "^2.0.20",
     "prettier": "^2.8.0",
     "supertest": "^6.3.3",

--- a/scripts/dbSetup.ts
+++ b/scripts/dbSetup.ts
@@ -1,6 +1,9 @@
 import { Connection } from '../src/db/Connection';
 import * as fs from 'fs';
+import * as dotenv from 'dotenv';
 import { MongoError } from 'mongodb';
+
+dotenv.config();
 
 const DB_URL = process.env.DATABASE_URL || 'mongodb://localhost:27017/measure-repository';
 const COLLECTION_NAMES = ['Measure', 'Library', 'MeasureReport'];

--- a/src/services/LibraryService.ts
+++ b/src/services/LibraryService.ts
@@ -86,6 +86,6 @@ export class LibraryService implements Service<fhir4.Library> {
       );
     }
 
-    return createLibraryPackageBundle(library[0]);
+    return createLibraryPackageBundle(library[0], req.query['include-terminology'] ?? false);
   }
 }

--- a/src/services/MeasureService.ts
+++ b/src/services/MeasureService.ts
@@ -6,7 +6,7 @@ import { createMeasurePackageBundle, createSearchsetBundle } from '../util/bundl
 import { BadRequestError, ResourceNotFoundError } from '../util/errorUtils';
 import { getMongoQueryFromRequest } from '../util/queryUtils';
 import { gatherParams, validateSearchParams } from '../util/validationUtils';
-import { Calculator, ValueSetResolver } from 'fqm-execution';
+import { Calculator } from 'fqm-execution';
 
 const logger = loggers.get('default');
 

--- a/src/services/MeasureService.ts
+++ b/src/services/MeasureService.ts
@@ -6,7 +6,7 @@ import { createMeasurePackageBundle, createSearchsetBundle } from '../util/bundl
 import { BadRequestError, ResourceNotFoundError } from '../util/errorUtils';
 import { getMongoQueryFromRequest } from '../util/queryUtils';
 import { gatherParams, validateSearchParams } from '../util/validationUtils';
-import { Calculator } from 'fqm-execution';
+import { Calculator, ValueSetResolver } from 'fqm-execution';
 
 const logger = loggers.get('default');
 
@@ -87,7 +87,7 @@ export class MeasureService implements Service<fhir4.Measure> {
       );
     }
 
-    return createMeasurePackageBundle(measure[0]);
+    return createMeasurePackageBundle(measure[0], req.query['include-terminology'] ?? false);
   }
 
   /**

--- a/src/types/node-fhir-server-core.d.ts
+++ b/src/types/node-fhir-server-core.d.ts
@@ -110,6 +110,10 @@ declare module '@projecttacoma/node-fhir-server-core' {
 
   export type ServerConfig = {
     profiles: Partial<Record<FhirResourceType, ProfileConfig>>;
+    statementGenerator?: (args: RequestArgs) => {
+      makeStatement: (resources: any) => fhir4.CapabilityStatement;
+      securityStatement: () => any;
+    };
   };
 
   export class ServerError extends Error {

--- a/src/util/bundleUtils.ts
+++ b/src/util/bundleUtils.ts
@@ -126,8 +126,8 @@ export async function getDependentValueSets(lib: fhir4.Library, useFileCache = t
   logger.info('Resolving ValueSets');
 
   const depValueSetUrls = (
-    lib.relatedArtifact
-      ?.filter(ra => ra.type === 'depends-on' && ra.resource?.includes('ValueSet'))
+    (lib.relatedArtifact as fhir4.RelatedArtifact[])
+      .filter(ra => ra.type === 'depends-on' && ra.resource?.includes('ValueSet'))
       .map(ra => ra.resource as string) ?? []
   )
     // TODO: This URL throws an internal server error on VSAC
@@ -204,11 +204,12 @@ export async function getAllDependentLibraries(lib: fhir4.Library): Promise<fhir
   const results = [lib];
 
   // If the library has no dependencies, we are done
-  if (!lib.relatedArtifact || (Array.isArray(lib.relatedArtifact) && lib.relatedArtifact.length === 0)) {
+  if (hasNoDependencies(lib)) {
     return results;
   }
+
   // This filter checks for the 'Library' keyword on all related artifacts
-  const depLibUrls = lib.relatedArtifact
+  const depLibUrls = (lib.relatedArtifact as fhir4.RelatedArtifact[])
     .filter(
       ra =>
         ra.type === 'depends-on' &&

--- a/src/util/bundleUtils.ts
+++ b/src/util/bundleUtils.ts
@@ -1,8 +1,10 @@
 import { loggers } from '@projecttacoma/node-fhir-server-core';
+import { ValueSetResolver } from 'fqm-execution';
 import { Filter } from 'mongodb';
 import { v4 } from 'uuid';
 import { findResourcesWithQuery } from '../db/dbOperations';
 import { BadRequestError, ResourceNotFoundError } from '../util/errorUtils';
+import fs from 'fs';
 
 const logger = loggers.get('default');
 
@@ -25,7 +27,10 @@ export function createSearchsetBundle<T extends fhir4.FhirResource>(entries: T[]
  * Takes in a measure resource, finds all dependent library resources and bundles them
  * together with the measure in a collection bundle
  */
-export async function createMeasurePackageBundle(measure: fhir4.Measure): Promise<fhir4.Bundle<fhir4.FhirResource>> {
+export async function createMeasurePackageBundle(
+  measure: fhir4.Measure,
+  includeTerminology?: boolean
+): Promise<fhir4.Bundle<fhir4.FhirResource>> {
   logger.info(`Assembling collection bundle from Measure ${measure.id}`);
   if (measure.library && measure.library.length > 0) {
     const [mainLibraryRef] = measure.library;
@@ -39,6 +44,16 @@ export async function createMeasurePackageBundle(measure: fhir4.Measure): Promis
     const result = await createDepLibraryBundle(mainLib);
     result.entry?.unshift({ resource: measure });
 
+    if (includeTerminology) {
+      const valueSets = await getDependentValueSets(mainLib);
+
+      result.entry?.push(
+        ...valueSets.map(vs => ({
+          resource: vs
+        }))
+      );
+    }
+
     return result;
   } else {
     throw new BadRequestError(`Uploaded measure: ${measure.id} does not reference a Library`);
@@ -49,9 +64,22 @@ export async function createMeasurePackageBundle(measure: fhir4.Measure): Promis
  * Takes in a library resource, finds all dependent library resources and bundles them
  * together with the library in a collection bundle
  */
-export async function createLibraryPackageBundle(library: fhir4.Library): Promise<fhir4.Bundle<fhir4.FhirResource>> {
+export async function createLibraryPackageBundle(
+  library: fhir4.Library,
+  includeTerminology?: boolean
+): Promise<fhir4.Bundle<fhir4.FhirResource>> {
   logger.info(`Assembling collection bundle from Library ${library.id}`);
   const result = await createDepLibraryBundle(library);
+
+  if (includeTerminology) {
+    const valueSets = await getDependentValueSets(library);
+
+    result.entry?.push(
+      ...valueSets.map(vs => ({
+        resource: vs
+      }))
+    );
+  }
 
   return result;
 }
@@ -84,6 +112,75 @@ export function getQueryFromReference(reference: string): Filter<any> {
   } else {
     return { url: reference };
   }
+}
+
+function hasNoDependencies(lib: fhir4.Library) {
+  return !lib.relatedArtifact || (Array.isArray(lib.relatedArtifact) && lib.relatedArtifact.length === 0);
+}
+
+export async function getDependentValueSets(lib: fhir4.Library) {
+  if (hasNoDependencies(lib)) {
+    return [];
+  }
+
+  logger.info('Resolving ValueSets');
+
+  const depValueSetUrls =
+    lib.relatedArtifact
+      ?.filter(ra => ra.type === 'depends-on' && ra.resource?.includes('ValueSet'))
+      .map(ra => ra.resource as string) ?? [];
+
+  const valueSets: fhir4.ValueSet[] = [];
+  const missingUrls: string[] = [];
+
+  if (fs.existsSync('./cache')) {
+    const cacheLookup = fs
+      .readdirSync('./cache')
+      .map(f => JSON.parse(fs.readFileSync(`./cache/${f}`, 'utf8')) as fhir4.ValueSet)
+      .reduce((lookup, vs) => {
+        if (vs.url) {
+          lookup[vs.url] = vs;
+        }
+
+        return lookup;
+      }, {} as Record<string, fhir4.ValueSet>);
+
+    depValueSetUrls.forEach(url => {
+      // TODO: This URL throws an internal server error on VSAC
+      // Ignore for now just to test caching
+      if (url === 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591') return;
+
+      if (cacheLookup[url]) {
+        logger.debug(`Found ${url} in cache`);
+        valueSets.push(cacheLookup[url]);
+      } else {
+        logger.debug(`Could not find ${url} in cache`);
+        missingUrls.push(url);
+      }
+    });
+  } else {
+    fs.mkdirSync('./cache');
+  }
+
+  // If we didn't find all in the cache, need to resolve via VSAC
+  if (missingUrls.length > 0) {
+    const valueSetResolver = new ValueSetResolver(process.env.VSAC_API_KEY ?? '');
+
+    const [resolvedValueSets, errors] = await valueSetResolver.getExpansionForValuesetUrls(depValueSetUrls);
+
+    resolvedValueSets.forEach(vs => {
+      fs.writeFileSync(`./cache/${vs.id}.json`, JSON.stringify(vs));
+      logger.debug(`Wrote ${vs.url} to cache`);
+    });
+
+    if (errors.length > 0) {
+      throw new Error(`Errors encountered resolving ValueSets: ${errors.join(', ')}`);
+    }
+
+    valueSets.push(...resolvedValueSets);
+  }
+
+  return valueSets;
 }
 
 /**

--- a/src/util/bundleUtils.ts
+++ b/src/util/bundleUtils.ts
@@ -164,7 +164,13 @@ export async function getDependentValueSets(lib: fhir4.Library) {
 
   // If we didn't find all in the cache, need to resolve via VSAC
   if (missingUrls.length > 0) {
-    const valueSetResolver = new ValueSetResolver(process.env.VSAC_API_KEY ?? '');
+    if (!process.env.VSAC_API_KEY) {
+      throw new Error(
+        'Attempting to resolve ValueSets, but no API key found. Add "VSAC_API_KEY" to your local .env file'
+      );
+    }
+
+    const valueSetResolver = new ValueSetResolver(process.env.VSAC_API_KEY);
 
     const [resolvedValueSets, errors] = await valueSetResolver.getExpansionForValuesetUrls(depValueSetUrls);
 

--- a/src/util/bundleUtils.ts
+++ b/src/util/bundleUtils.ts
@@ -119,14 +119,10 @@ export async function getDependentValueSets(lib: fhir4.Library, useFileCache = t
 
   logger.info('Resolving ValueSets');
 
-  const depValueSetUrls = (
+  const depValueSetUrls =
     (lib.relatedArtifact as fhir4.RelatedArtifact[])
       .filter(ra => ra.type === 'depends-on' && ra.resource?.includes('ValueSet'))
-      .map(ra => ra.resource as string) ?? []
-  )
-    // TODO: This URL throws an internal server error on VSAC
-    // ticket has been submitted to the VSAC FHIR API team to look into this issue
-    .filter(url => url !== 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591');
+      .map(ra => ra.resource as string) ?? [];
 
   const valueSets: fhir4.ValueSet[] = [];
   let missingUrls: string[] = [];

--- a/test/services/MeasureService.test.ts
+++ b/test/services/MeasureService.test.ts
@@ -374,10 +374,7 @@ describe('MeasureService', () => {
             expect.objectContaining({
               resourceType: 'Bundle'
             }),
-            expect.objectContaining({
-              measurementPeriodStart: '2022-01-01',
-              measurementPeriodEnd: '2022-12-31'
-            })
+            {}
           );
         });
     });
@@ -394,10 +391,7 @@ describe('MeasureService', () => {
             expect.objectContaining({
               resourceType: 'Bundle'
             }),
-            expect.objectContaining({
-              measurementPeriodStart: '2022-01-01',
-              measurementPeriodEnd: '2022-12-31'
-            })
+            {}
           );
         });
     });

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,4 +1,7 @@
 import { loggers } from '@projecttacoma/node-fhir-server-core';
+import dotenv from 'dotenv';
+
+dotenv.config({ path: '.env.test' });
 
 const logger = loggers.get('default');
 logger.silent = true;

--- a/test/util/bundleUtils.test.ts
+++ b/test/util/bundleUtils.test.ts
@@ -21,6 +21,12 @@ const MOCK_VS_2: fhir4.ValueSet = {
   url: 'http://example.com/ValueSet/2'
 };
 
+const MOCK_VS_3: fhir4.ValueSet = {
+  resourceType: 'ValueSet',
+  status: 'unknown',
+  url: 'http://example.com/ValueSet/4'
+};
+
 const LIB_WITH_NO_DEPS: fhir4.Library = {
   id: 'LibWithNoDeps',
   url: 'http://example.com/LibraryWithNoDeps',
@@ -47,6 +53,42 @@ const LIB_WITH_DEPS: fhir4.Library = {
     {
       type: 'depends-on',
       resource: MOCK_VS_2.url
+    }
+  ]
+};
+
+const LIB_WITH_VALUESET: fhir4.Library = {
+  id: 'LibraryWithValueSet',
+  url: 'http://example.com/LibraryWithVS',
+  resourceType: 'Library',
+  status: 'draft',
+  type: { coding: [{ code: 'logic-library' }] },
+  relatedArtifact: [
+    {
+      type: 'depends-on',
+      resource: 'http://example.com/LibraryWithExtraVS'
+    },
+    {
+      type: 'depends-on',
+      resource: MOCK_VS_1.url
+    },
+    {
+      type: 'depends-on',
+      resource: MOCK_VS_2.url
+    }
+  ]
+};
+
+const LIB_WITH_EXTRA_VALUESET: fhir4.Library = {
+  id: 'LibraryWithExtraValueSet',
+  url: 'http://example.com/LibraryWithExtraVS',
+  resourceType: 'Library',
+  status: 'draft',
+  type: { coding: [{ code: 'logic-library' }] },
+  relatedArtifact: [
+    {
+      type: 'depends-on',
+      resource: MOCK_VS_3.url
     }
   ]
 };
@@ -87,7 +129,13 @@ const MEASURE_WITH_LIBRARY: fhir4.Measure = {
 
 describe('bundleUtils', () => {
   beforeAll(() => {
-    return setupTestDatabase([LIB_WITH_DEPS, LIB_WITH_NO_DEPS, LIB_WITH_MISSING_DEPS]);
+    return setupTestDatabase([
+      LIB_WITH_DEPS,
+      LIB_WITH_NO_DEPS,
+      LIB_WITH_MISSING_DEPS,
+      LIB_WITH_EXTRA_VALUESET,
+      LIB_WITH_EXTRA_VALUESET
+    ]);
   });
 
   describe('Testing getAllDependentLibraries()', () => {
@@ -142,6 +190,31 @@ describe('bundleUtils', () => {
       expect(libBundle.entry).toHaveLength(2);
       expect(libBundle.entry).toEqual(
         expect.arrayContaining([{ resource: LIB_WITH_DEPS }, { resource: LIB_WITH_NO_DEPS }])
+      );
+    });
+
+    it('should include all valuesets across libraries when using terminology', async () => {
+      nock(MOCK_VS_1.url as string)
+        .get('/$expand')
+        .reply(200, MOCK_VS_1);
+      nock(MOCK_VS_2.url as string)
+        .get('/$expand')
+        .reply(200, MOCK_VS_2);
+      nock(MOCK_VS_3.url as string)
+        .get('/$expand')
+        .reply(200, MOCK_VS_3);
+
+      const libBundle = await createDepLibraryBundle(LIB_WITH_VALUESET, true);
+      expect(libBundle.resourceType).toEqual('Bundle');
+      expect(libBundle.entry).toHaveLength(5);
+      expect(libBundle.entry).toEqual(
+        expect.arrayContaining([
+          { resource: LIB_WITH_VALUESET },
+          { resource: LIB_WITH_EXTRA_VALUESET },
+          { resource: MOCK_VS_1 },
+          { resource: MOCK_VS_2 },
+          { resource: MOCK_VS_3 }
+        ])
       );
     });
   });
@@ -208,7 +281,7 @@ describe('bundleUtils', () => {
         .get('/$expand')
         .reply(200, MOCK_VS_2);
 
-      const vs = await getDependentValueSets(LIB_WITH_DEPS, false);
+      const vs = await getDependentValueSets(LIB_WITH_VALUESET, false);
 
       expect(vs).toHaveLength(2);
       expect(vs).toEqual(expect.arrayContaining([MOCK_VS_1, MOCK_VS_2]));

--- a/test/util/bundleUtils.test.ts
+++ b/test/util/bundleUtils.test.ts
@@ -133,7 +133,6 @@ describe('bundleUtils', () => {
       LIB_WITH_DEPS,
       LIB_WITH_NO_DEPS,
       LIB_WITH_MISSING_DEPS,
-      LIB_WITH_EXTRA_VALUESET,
       LIB_WITH_EXTRA_VALUESET
     ]);
   });


### PR DESCRIPTION
~Depends on https://github.com/projecttacoma/fqm-execution/pull/186 since it uses the newly-exported ValueSetResolver class with the updated VSAC URL~

~For this to be merged, a new patch version with the linked changes will be released and brought into this code as a dependency.~

# Summary

This PR includes changes worked on at the January '23 connectathon. Mainly, support for using the VSAC FHIR API during measure packaging, which is useful for the end-to-end workflow demonstration of knowledge repository queries all the way through data submission and measure evaluation.

Besides that, some various QOL updates are included here, such as typescript updates for a custom capability statement and fixes to the period start/end of data requirements to make them not required.

## New behavior

* When using the `include-terminology` query parameter, the server will resolve any missing ValueSets and cache them in the file system.
  * Looking for feedback on the disabling of caching in unit tests and if that should change in any way
* periodStart/end are omitted from the calculation options of fqm-execution if they are not provided in the query params for data requirements
  * Technically this will trigger the default 2019 behavior of fqm-execution, but that will be addressed in separate tasking.

## Code changes

* Bring in valueset resolver and use it in packaging when include-terminology is true.
* Conditionally add periodStart/end based on if they're provided
* Add unit tests for valueset resolution
* Update node-fhir-server-core type defs to adhere to [custom capability docs](https://github.com/bluehalo/node-fhir-server-core/blob/master/docs/CustomCapability.md)

# Testing guidance

* To test valueset resolution, add your VSAC API key to .env (see .env.example)
* Run a $package operation with `include-terminology` set to `true` in the query parameters. It will take a long time
  * You'll see in the logs that it resolves and caches the valuesets
* Run the same request again. It should take basically no time at all since it uses a cache. Check the logs to confirm behavior
