### PR TITLE
Add custom capability statement

### DIFF
--- a/src/config/capabilityStatementResources.json
+++ b/src/config/capabilityStatementResources.json
@@ -54,7 +54,7 @@
           ],
           "name" : "version",
           "definition" : "http://hl7.org/fhir/SearchParameter/Library-version",
-          "type" : "token"
+          "type" : "string"
         },
         {
           "extension" : [
@@ -120,14 +120,6 @@
           }],
           "name" : "package",
           "definition" : "http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Library-package"
-        },
-        {
-          "extension" : [{
-            "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-            "valueCode" : "SHALL"
-          }],
-          "name" : "data-requirements",
-          "definition" : "http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Library-data-requirements"
         }
       ]
     },
@@ -186,7 +178,7 @@
           ],
           "name" : "version",
           "definition" : "http://hl7.org/fhir/SearchParameter/Measure-version",
-          "type" : "token"
+          "type" : "string"
         },
         {
           "extension" : [

--- a/src/config/capabilityStatementResources.json
+++ b/src/config/capabilityStatementResources.json
@@ -1,0 +1,267 @@
+{
+  "mode": "server",
+  "resource": [
+    {
+      "type" : "Library",
+      "profile" : "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/library-cqfm",
+      "supportedProfile" : [
+        "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/computable-library-cqfm",
+        "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/publishable-library-cqfm",
+        "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/executable-library-cqfm",
+        "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/modelinfo-library-cqfm",
+        "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/quality-program-cqfm"
+      ],
+      "interaction" : [
+        {
+          "extension" : [
+            {
+              "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode" : "SHALL"
+            }
+          ],
+          "code" : "read",
+          "documentation" : "Read allows clients to get the definitions and details of repository libraries"
+        },
+        {
+          "extension" : [
+            {
+              "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode" : "SHALL"
+            }
+          ],
+          "code" : "search-type",
+          "documentation" : "Search allows clients to search for repository libraries"
+        }
+      ],
+      "searchParam" : [
+        {
+          "extension" : [
+            {
+              "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode" : "SHALL"
+            }
+          ],
+          "name" : "url",
+          "definition" : "http://hl7.org/fhir/SearchParameter/Library-url",
+          "type" : "uri"
+        },
+        {
+          "extension" : [
+            {
+              "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode" : "SHALL"
+            }
+          ],
+          "name" : "version",
+          "definition" : "http://hl7.org/fhir/SearchParameter/Library-version",
+          "type" : "token"
+        },
+        {
+          "extension" : [
+            {
+              "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode" : "SHALL"
+            }
+          ],
+          "name" : "identifier",
+          "definition" : "http://hl7.org/fhir/SearchParameter/Library-identifier",
+          "type" : "token"
+        },
+        {
+          "extension" : [
+            {
+              "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode" : "SHALL"
+            }
+          ],
+          "name" : "name",
+          "definition" : "http://hl7.org/fhir/SearchParameter/Library-name",
+          "type" : "string"
+        },
+        {
+          "extension" : [
+            {
+              "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode" : "SHALL"
+            }
+          ],
+          "name" : "title",
+          "definition" : "http://hl7.org/fhir/SearchParameter/Library-title",
+          "type" : "string"
+        },
+        {
+          "extension" : [
+            {
+              "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode" : "SHALL"
+            }
+          ],
+          "name" : "description",
+          "definition" : "http://hl7.org/fhir/SearchParameter/Library-description",
+          "type" : "string"
+        },
+        {
+          "extension" : [
+            {
+              "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode" : "SHALL"
+            }
+          ],
+          "name" : "status",
+          "definition" : "http://hl7.org/fhir/SearchParameter/Library-status",
+          "type" : "token"
+        }
+      ],
+      "operation": [
+        {
+          "extension" : [{
+            "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+            "valueCode" : "SHALL"
+          }],
+          "name" : "package",
+          "definition" : "http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Library-package"
+        },
+        {
+          "extension" : [{
+            "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+            "valueCode" : "SHALL"
+          }],
+          "name" : "data-requirements",
+          "definition" : "http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Library-data-requirements"
+        }
+      ]
+    },
+    {
+      "type" : "Measure",
+      "profile" : "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/measure-cqfm",
+      "supportedProfile" : [
+        "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/computable-measure-cqfm",
+        "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/publishable-measure-cqfm",
+        "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cohort-measure-cqfm",
+        "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/proportion-measure-cqfm",
+        "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/ratio-measure-cqfm",
+        "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cv-measure-cqfm",
+        "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/composite-measure-cqfm"
+      ],
+      "interaction" : [
+        {
+          "extension" : [
+            {
+              "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode" : "SHALL"
+            }
+          ],
+          "code" : "read",
+          "documentation" : "Read allows clients to get the definitions and details of repository measures"
+        },
+        {
+          "extension" : [
+            {
+              "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode" : "SHALL"
+            }
+          ],
+          "code" : "search-type",
+          "documentation" : "Search allows clients to search for repository measures"
+        }
+      ],
+      "searchParam" : [
+        {
+          "extension" : [
+            {
+              "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode" : "SHALL"
+            }
+          ],
+          "name" : "url",
+          "definition" : "http://hl7.org/fhir/SearchParameter/Measure-url",
+          "type" : "uri"
+        },
+        {
+          "extension" : [
+            {
+              "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode" : "SHALL"
+            }
+          ],
+          "name" : "version",
+          "definition" : "http://hl7.org/fhir/SearchParameter/Measure-version",
+          "type" : "token"
+        },
+        {
+          "extension" : [
+            {
+              "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode" : "SHALL"
+            }
+          ],
+          "name" : "identifier",
+          "definition" : "http://hl7.org/fhir/SearchParameter/Measure-identifier",
+          "type" : "token"
+        },
+        {
+          "extension" : [
+            {
+              "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode" : "SHALL"
+            }
+          ],
+          "name" : "name",
+          "definition" : "http://hl7.org/fhir/SearchParameter/Measure-name",
+          "type" : "string"
+        },
+        {
+          "extension" : [
+            {
+              "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode" : "SHALL"
+            }
+          ],
+          "name" : "title",
+          "definition" : "http://hl7.org/fhir/SearchParameter/Measure-title",
+          "type" : "string"
+        },
+        {
+          "extension" : [
+            {
+              "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode" : "SHALL"
+            }
+          ],
+          "name" : "description",
+          "definition" : "http://hl7.org/fhir/SearchParameter/Measure-description",
+          "type" : "string"
+        },
+        {
+          "extension" : [
+            {
+              "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode" : "SHALL"
+            }
+          ],
+          "name" : "status",
+          "definition" : "http://hl7.org/fhir/SearchParameter/Measure-status",
+          "type" : "token"
+        }
+      ],
+      "operation": [
+        {
+          "extension" : [{
+            "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+            "valueCode" : "SHALL"
+          }],
+          "name" : "package",
+          "definition" : "http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Measure-package"
+        },
+        {
+          "extension" : [{
+            "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+            "valueCode" : "SHALL"
+          }],
+          "name" : "data-requirements",
+          "definition" : "http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Measure-data-requirements"
+        }
+      ]
+    }
+  ]
+}

--- a/src/config/serverConfig.ts
+++ b/src/config/serverConfig.ts
@@ -12,13 +12,16 @@ const customCapabilityStatement = (): fhir4.CapabilityStatement => {
     title: 'FHIR Measure Repository Service Capability Statement',
     status: 'active',
     // date last modified
-    date: '2023-01-27',
+    date: new Date(2023, 0, 31),
     publisher: 'The MITRE Corporation',
     instantiates: [
       'http://hl7.org/fhir/us/cqfmeasures/CapabilityStatement/shareable-measure-repository',
       'http://hl7.org/fhir/us/cqfmeasures/CapabilityStatement/publishable-measure-repository'
     ],
     kind: 'instance',
+    implementation: {
+      description: 'A prototype implementation of a FHIR Measure Repository Service'
+    },
     fhirVersion: base_version.replace(/_/g, '.'),
     format: ['application/fhir+json'],
     rest: [capabilityStatementResources]

--- a/src/config/serverConfig.ts
+++ b/src/config/serverConfig.ts
@@ -1,5 +1,29 @@
-import { constants, ServerConfig } from '@projecttacoma/node-fhir-server-core';
+import { constants, ServerConfig, resolveSchema } from '@projecttacoma/node-fhir-server-core';
 import { MeasureService, LibraryService } from '../services';
+import capabilityStatementResources from './capabilityStatementResources.json';
+
+const customCapabilityStatement = (): fhir4.CapabilityStatement => {
+  const base_version = constants.VERSIONS['4_0_1'];
+  const CapabilityStatement = resolveSchema(base_version, 'CapabilityStatement');
+
+  return new CapabilityStatement({
+    id: 'MeasureRepositoryServiceCapabilityStatement',
+    name: 'MeasureRepositoryService',
+    title: 'FHIR Measure Repository Service Capability Statement',
+    status: 'active',
+    // date last modified
+    date: '2023-01-27',
+    publisher: 'The MITRE Corporation',
+    instantiates: [
+      'http://hl7.org/fhir/us/cqfmeasures/CapabilityStatement/shareable-measure-repository',
+      'http://hl7.org/fhir/us/cqfmeasures/CapabilityStatement/publishable-measure-repository'
+    ],
+    kind: 'instance',
+    fhirVersion: base_version.replace(/_/g, '.'),
+    format: ['application/fhir+json'],
+    rest: [capabilityStatementResources]
+  });
+};
 
 export const serverConfig: ServerConfig = {
   profiles: {
@@ -87,5 +111,8 @@ export const serverConfig: ServerConfig = {
         }
       ]
     }
+  },
+  statementGenerator() {
+    return { makeStatement: customCapabilityStatement, securityStatement: () => null };
   }
 };

--- a/src/types/node-fhir-server-core.d.ts
+++ b/src/types/node-fhir-server-core.d.ts
@@ -110,7 +110,7 @@ declare module '@projecttacoma/node-fhir-server-core' {
 
   export type ServerConfig = {
     profiles: Partial<Record<FhirResourceType, ProfileConfig>>;
-    statementGenerator?: (args: RequestArgs) => {
+    statementGenerator?: () => {
       makeStatement: (resources: any) => fhir4.CapabilityStatement;
       securityStatement: () => any;
     };


### PR DESCRIPTION
# Summary
Adds a custom capability statement of kind “instance” that covers the current capabilities of the measure repository service. It is accessible via the `/metadata` endpoint.

## New behavior
Creates a custom capability statement that reflects the current state of the measure repository service, specifically in regard to the requirements for a Shareable Measure Repository and Publishable Measure Repository. Note the use of the kind “instance,” which requires an implementation to be present and describes its capabilities. Whereas the [Publishable M.R.’s capability statement](https://build.fhir.org/ig/HL7/cqf-measures/CapabilityStatement-publishable-measure-repository.json.html) imports the capability statement for the Shareable M.R., this instance capability statement does not (this is something we can change in the future if the single capability statement gets too unruly, but for now I think it’s small enough to include everything in a single cap. statement.)

This capability statement currently only includes the SHALL operations and search params that we support. As we implement SHOULD operations and search params, we will need to update the capability statement accordingly and amend its date (the date represents the date last updated).

To access the capability statement, send a GET request to `http://localhost:3000/4_0_1/metadata`.

## Code changes
* Updated the `serverConfig` to create a new custom capability statement with the `statementGenerator` that was recently added to `node-fhir-server-core.d.ts`
* Added a JSON file containing the definition of RESTful capabilities of the server

Some design decisions (that I’m open to feedback on):
* I removed the `RequestArgs` input from the `statementGenerator` and instead defaulted to version 4_0_1. In the future I imagine we want to support multiple FHIR versions, but for now I figure it is fine to default to 4_0_1 since we default the Measure/Library profiles to only support version 4_0_1
* Node-fhir-server-core does create a default `rest` array based on the defined profiles and operations in the`serverConfig`; however, I found it difficult to really use any of it, which is why I created a separate JSON containing the desired contents of the `rest` array. If you send a GET request to `http://localhost:3000/4_0_1/metadata` from the main branch, you can see the capability statement that gets automatically generated. The resource types contain search params that the server does not support, and there are duplicate operations reflected (due to how we define them in the `serverConfig`). Rather than try to take bits and pieces from this, I think it would be more clear to the developer if we stashed the `rest` contents in a separate JSON.
* The default cap. statement that gets generated includes the `operation` array at the `rest` level. However, the operations can instead be defined for each resource type. According to the [spec](https://www.hl7.org/fhir/capabilitystatement-definitions.html#CapabilityStatement.rest.operation), “CapabilityStatement.rest.operation is for operations invoked at the system level, or for operations that are supported across multiple resource types.” When defined on the resource, the [spec](https://www.hl7.org/fhir/capabilitystatement-definitions.html#CapabilityStatement.rest.resource.operation) says “If an operation that is listed in multiple CapabilityStatement.rest.resource.operation (e.g. for different resource types), then clients should understand the the operation is only supported on the specified resource types.” From this, I decided to put the `package` and `data-requirements` operations under Library and Measure resources rather than have them inferred as system-level operations.
* I included SHALL extensions (they are used in the requirements cap. statements for Shareable/Publishable) but we can remove them if they aren’t needed. I figure they might be useful for future cap. statement tests in the test kit.

# Testing guidance
* Send GET request to the endpoint (`http://localhost:3000/4_0_1/metadata`)
* Inspect the contents to ensure that they align with the spec
    * all required fields are present
    * fields like “instantiates” and “format” are correct
    * The correct interactions, search params, and operations are present for each resource type
    * Look at the spec and see if there are any optional fields not reflected in the cap. statement that we should include
