### PR TITLE
Error for path parameter w/ query or fhir param

### DIFF
--- a/src/services/LibraryService.ts
+++ b/src/services/LibraryService.ts
@@ -5,7 +5,7 @@ import { Service } from '../types/service';
 import { createLibraryPackageBundle, createSearchsetBundle } from '../util/bundleUtils';
 import { BadRequestError, ResourceNotFoundError } from '../util/errorUtils';
 import { getMongoQueryFromRequest } from '../util/queryUtils';
-import { gatherParams, validateSearchParams } from '../util/validationUtils';
+import { gatherParams, validateSearchParams, validateParamIdSource } from '../util/validationUtils';
 
 const logger = loggers.get('default');
 
@@ -51,11 +51,7 @@ export class LibraryService implements Service<fhir4.Library> {
     logger.info(`${req.method} ${req.path}`);
 
     const params = gatherParams(req.query, args.resource);
-    if (req.params.id && params.id) {
-      throw new BadRequestError(
-        'Id argument may not be sourced from both a path parameter and a query or fhir parameter.'
-      );
-    }
+    validateParamIdSource(req.params.id, params.id);
     const id = args.id || params.id;
     const url = params.url;
     const version = params.version;

--- a/src/services/LibraryService.ts
+++ b/src/services/LibraryService.ts
@@ -51,6 +51,11 @@ export class LibraryService implements Service<fhir4.Library> {
     logger.info(`${req.method} ${req.path}`);
 
     const params = gatherParams(req.query, args.resource);
+    if (req.params.id && params.id) {
+      throw new BadRequestError(
+        'Id argument may not be sourced from both a path parameter and a query or fhir parameter.'
+      );
+    }
     const id = args.id || params.id;
     const url = params.url;
     const version = params.version;

--- a/src/services/MeasureService.ts
+++ b/src/services/MeasureService.ts
@@ -52,6 +52,11 @@ export class MeasureService implements Service<fhir4.Measure> {
     logger.info(`${req.method} ${req.path}`);
 
     const params = gatherParams(req.query, args.resource);
+    if (req.params.id && params.id) {
+      throw new BadRequestError(
+        'Id argument may not be sourced from both a path parameter and a query or fhir parameter.'
+      );
+    }
     const id = args.id || params.id;
     const url = params.url;
     const version = params.version;

--- a/src/services/MeasureService.ts
+++ b/src/services/MeasureService.ts
@@ -5,7 +5,7 @@ import { Service } from '../types/service';
 import { createMeasurePackageBundle, createSearchsetBundle } from '../util/bundleUtils';
 import { BadRequestError, ResourceNotFoundError } from '../util/errorUtils';
 import { getMongoQueryFromRequest } from '../util/queryUtils';
-import { gatherParams, validateSearchParams } from '../util/validationUtils';
+import { gatherParams, validateSearchParams, validateParamIdSource } from '../util/validationUtils';
 import { Calculator } from 'fqm-execution';
 
 const logger = loggers.get('default');
@@ -52,11 +52,7 @@ export class MeasureService implements Service<fhir4.Measure> {
     logger.info(`${req.method} ${req.path}`);
 
     const params = gatherParams(req.query, args.resource);
-    if (req.params.id && params.id) {
-      throw new BadRequestError(
-        'Id argument may not be sourced from both a path parameter and a query or fhir parameter.'
-      );
-    }
+    validateParamIdSource(req.params.id, params.id);
     const id = args.id || params.id;
     const url = params.url;
     const version = params.version;

--- a/src/util/validationUtils.ts
+++ b/src/util/validationUtils.ts
@@ -40,3 +40,11 @@ export function gatherParams(query: RequestQuery, parameters?: fhir4.Parameters)
   }
   return gatheredParams;
 }
+
+export function validateParamIdSource(pathId: any, paramId: any) {
+  if (pathId && paramId) {
+    throw new BadRequestError(
+      'Id argument may not be sourced from both a path parameter and a query or FHIR parameter.'
+    );
+  }
+}

--- a/test/services/LibraryService.test.ts
+++ b/test/services/LibraryService.test.ts
@@ -317,6 +317,34 @@ describe('LibraryService', () => {
         });
     });
 
+    it('throws a 400 error when an id is included in both the path and a fhir parameter', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Library/testLibraryWithDeps/$package')
+        .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testLibraryWithDeps' }] })
+        .set('content-type', 'application/fhir+json')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].code).toEqual('invalid');
+          expect(response.body.issue[0].details.text).toEqual(
+            'Id argument may not be sourced from both a path parameter and a query or fhir parameter.'
+          );
+        });
+    });
+
+    it('throws a 400 error when an id is included in both the path and a query parameter', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Library/testLibraryWithDeps/$package')
+        .query({ id: 'testLibraryWithDeps' })
+        .set('content-type', 'application/fhir+json')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].code).toEqual('invalid');
+          expect(response.body.issue[0].details.text).toEqual(
+            'Id argument may not be sourced from both a path parameter and a query or fhir parameter.'
+          );
+        });
+    });
+
     it('throws a 404 error when both the library id and url are specified but one of them is invalid', async () => {
       await supertest(server.app)
         .post('/4_0_1/Library/$package')

--- a/test/services/LibraryService.test.ts
+++ b/test/services/LibraryService.test.ts
@@ -317,7 +317,7 @@ describe('LibraryService', () => {
         });
     });
 
-    it('throws a 400 error when an id is included in both the path and a fhir parameter', async () => {
+    it('throws a 400 error when an id is included in both the path and a FHIR parameter', async () => {
       await supertest(server.app)
         .post('/4_0_1/Library/testLibraryWithDeps/$package')
         .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testLibraryWithDeps' }] })
@@ -326,7 +326,7 @@ describe('LibraryService', () => {
         .then(response => {
           expect(response.body.issue[0].code).toEqual('invalid');
           expect(response.body.issue[0].details.text).toEqual(
-            'Id argument may not be sourced from both a path parameter and a query or fhir parameter.'
+            'Id argument may not be sourced from both a path parameter and a query or FHIR parameter.'
           );
         });
     });
@@ -340,7 +340,7 @@ describe('LibraryService', () => {
         .then(response => {
           expect(response.body.issue[0].code).toEqual('invalid');
           expect(response.body.issue[0].details.text).toEqual(
-            'Id argument may not be sourced from both a path parameter and a query or fhir parameter.'
+            'Id argument may not be sourced from both a path parameter and a query or FHIR parameter.'
           );
         });
     });

--- a/test/services/MeasureService.test.ts
+++ b/test/services/MeasureService.test.ts
@@ -326,6 +326,34 @@ describe('MeasureService', () => {
         });
     });
 
+    it('throws a 400 error when an id is included in both the path and a fhir parameter', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Measure/testWithRootLib/$package')
+        .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testWithRootLib' }] })
+        .set('content-type', 'application/fhir+json')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].code).toEqual('invalid');
+          expect(response.body.issue[0].details.text).toEqual(
+            'Id argument may not be sourced from both a path parameter and a query or fhir parameter.'
+          );
+        });
+    });
+
+    it('throws a 400 error when an id is included in both the path and a query parameter', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Measure/testWithRootLib/$package')
+        .query({ id: 'testWithRootLib' })
+        .set('content-type', 'application/fhir+json')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].code).toEqual('invalid');
+          expect(response.body.issue[0].details.text).toEqual(
+            'Id argument may not be sourced from both a path parameter and a query or fhir parameter.'
+          );
+        });
+    });
+
     it('throws a 404 error when no measure matching id and url can be found', async () => {
       await supertest(server.app)
         .post('/4_0_1/Measure/$package')
@@ -442,6 +470,34 @@ describe('MeasureService', () => {
               measurementPeriodStart: '2021-01-01',
               measurementPeriodEnd: '2021-12-31'
             })
+          );
+        });
+    });
+
+    it('throws a 400 error when an id is included in both the path and a fhir parameter', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Measure/testWithRootLib/$data-requirements')
+        .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testWithRootLib' }] })
+        .set('content-type', 'application/fhir+json')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].code).toEqual('invalid');
+          expect(response.body.issue[0].details.text).toEqual(
+            'Id argument may not be sourced from both a path parameter and a query or fhir parameter.'
+          );
+        });
+    });
+
+    it('throws a 400 error when an id is included in both the path and a query parameter', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Measure/testWithRootLib/$data-requirements')
+        .query({ id: 'testWithRootLib' })
+        .set('content-type', 'application/fhir+json')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].code).toEqual('invalid');
+          expect(response.body.issue[0].details.text).toEqual(
+            'Id argument may not be sourced from both a path parameter and a query or fhir parameter.'
           );
         });
     });

--- a/test/services/MeasureService.test.ts
+++ b/test/services/MeasureService.test.ts
@@ -326,7 +326,7 @@ describe('MeasureService', () => {
         });
     });
 
-    it('throws a 400 error when an id is included in both the path and a fhir parameter', async () => {
+    it('throws a 400 error when an id is included in both the path and a FHIR parameter', async () => {
       await supertest(server.app)
         .post('/4_0_1/Measure/testWithRootLib/$package')
         .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testWithRootLib' }] })
@@ -335,7 +335,7 @@ describe('MeasureService', () => {
         .then(response => {
           expect(response.body.issue[0].code).toEqual('invalid');
           expect(response.body.issue[0].details.text).toEqual(
-            'Id argument may not be sourced from both a path parameter and a query or fhir parameter.'
+            'Id argument may not be sourced from both a path parameter and a query or FHIR parameter.'
           );
         });
     });
@@ -349,7 +349,7 @@ describe('MeasureService', () => {
         .then(response => {
           expect(response.body.issue[0].code).toEqual('invalid');
           expect(response.body.issue[0].details.text).toEqual(
-            'Id argument may not be sourced from both a path parameter and a query or fhir parameter.'
+            'Id argument may not be sourced from both a path parameter and a query or FHIR parameter.'
           );
         });
     });
@@ -474,7 +474,7 @@ describe('MeasureService', () => {
         });
     });
 
-    it('throws a 400 error when an id is included in both the path and a fhir parameter', async () => {
+    it('throws a 400 error when an id is included in both the path and a FHIR parameter', async () => {
       await supertest(server.app)
         .post('/4_0_1/Measure/testWithRootLib/$data-requirements')
         .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testWithRootLib' }] })
@@ -483,7 +483,7 @@ describe('MeasureService', () => {
         .then(response => {
           expect(response.body.issue[0].code).toEqual('invalid');
           expect(response.body.issue[0].details.text).toEqual(
-            'Id argument may not be sourced from both a path parameter and a query or fhir parameter.'
+            'Id argument may not be sourced from both a path parameter and a query or FHIR parameter.'
           );
         });
     });
@@ -497,7 +497,7 @@ describe('MeasureService', () => {
         .then(response => {
           expect(response.body.issue[0].code).toEqual('invalid');
           expect(response.body.issue[0].details.text).toEqual(
-            'Id argument may not be sourced from both a path parameter and a query or fhir parameter.'
+            'Id argument may not be sourced from both a path parameter and a query or FHIR parameter.'
           );
         });
     });


### PR DESCRIPTION
# Summary
Adds stricter checking for overlapping id fields. For both `$package` and `$data-requirements`, id can be given as part of the path itself, as in this path parameter: `4_0_1/Measure/:id/$data-requirements`, or the id may be passed as a query parameter (GET) or part of a FHIR parameters object used in a POST. If the id is in both the path and one of these other parameters, the server should throw a 400 bad request error.

## New behavior
Throws 400 bad request for redundant id input, even if the value of the id parameter is the same.

## Code changes

- Updates parameter checking in `package` function for `LibraryService` and `MeasureService`. This function is used for parameter checking in both the `$package` and `$data-requirements` operations. Uses `req.params.id` to determine whether the path parameter is used (Note: `args` cannot be used for this because `args` also collects query parameters).
- Adds tests for (Library, Measure) x ($package, $data-requirements) x (POST, GET), 6 total.


# Testing guidance
`npm run check`

For database setup:
- `git clone https://github.com/cqframework/ecqm-content-r4-2021.git`
- `npm run db:reset`
- `npm run db:loadBundle "ecqm-content-r4-2021/bundles/measure/ColorectalCancerScreeningsFHIR/ColorectalCancerScreeningsFHIR-bundle.json"`

General testing:
- `npm start`
- Use insomnia or postman to test with various combinations of Library, Measure, data-requirements, package, POST, GET, and using path parameter or not.
- Example invalid GET: `http://localhost:3000/4_0_1/Measure/ColorectalCancerScreeningsFHIR/$package?id=ColorectalCancerScreeningsFHIR`
- Example invalid POST: `http://localhost:3000/4_0_1/Measure/ColorectalCancerScreeningsFHIR/$data-requirements` with fhir parameter object:
`{
  "resourceType": "Parameters",
  "parameter": [
    {
        "name": "id",
        "valueString": "ColorectalCancerScreeningsFHIR"
    },
    {
        "name": "periodStart",
        "valueDate": "2021-01-01"
    },
    {
        "name": "periodEnd",
        "valueDate": "2021-12-31"
    }
  ]
}`