### PR TITLE
Expose $submit operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Supported optional parameters are:
 - periodEnd
 
 ### Submit
-The Measure Repository Service server supports the `$submit` operation for Measure and Library resources, as specified in the Authoring Measure Repository serction of the [HL7 Measure Repository Docs](https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#authoring-measure-repository). The operation does not take in any parameters. 
+The Measure Repository Service server supports the `$submit` operation for `Measure` and `Library` resources, as specified in the Authoring Measure Repository section of the [HL7 Measure Repository Docs](https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#authoring-measure-repository). The operation does not take in any parameters. 
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ Supported optional parameters are:
 - periodStart
 - periodEnd
 
+### Submit
+The Measure Repository Service server supports the `$submit` operation for Measure and Library resources, as specified in the Authoring Measure Repository serction of the [HL7 Measure Repository Docs](https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#authoring-measure-repository). The operation does not take in any parameters. 
+
 ## License
 
 Copyright 2022 The MITRE Corporation

--- a/package-lock.json
+++ b/package-lock.json
@@ -8886,7 +8886,8 @@
     },
     "node_modules/uuid": {
       "version": "9.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -14971,7 +14972,9 @@
       "version": "1.0.1"
     },
     "uuid": {
-      "version": "9.0.0"
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@projecttacoma/node-fhir-server-core": "^2.2.8",
         "dotenv": "^16.0.3",
+        "express": "^4.18.2",
         "fqm-execution": "^1.0.4",
         "mongodb": "^4.12.1",
         "uuid": "^9.0.0",
@@ -18,6 +19,7 @@
       },
       "devDependencies": {
         "@shelf/jest-mongodb": "^4.1.4",
+        "@types/express": "^4.17.17",
         "@types/fhir": "^0.0.35",
         "@types/jest": "^29.2.3",
         "@types/node": "^18.11.5",
@@ -2709,10 +2711,52 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "dev": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/cookiejar": {
       "version": "2.1.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.17",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
+      "integrity": "sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.17.33",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
+      "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
     },
     "node_modules/@types/fhir": {
       "version": "0.0.35",
@@ -2762,6 +2806,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mime": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
+      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "18.11.5",
       "license": "MIT"
@@ -2771,10 +2821,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "dev": true
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "dev": true
+    },
     "node_modules/@types/semver": {
       "version": "7.3.13",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
+      "dev": true,
+      "dependencies": {
+        "@types/mime": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -4778,7 +4850,8 @@
     },
     "node_modules/express": {
       "version": "4.18.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -11116,9 +11189,51 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/cookiejar": {
       "version": "2.1.2",
       "dev": true
+    },
+    "@types/express": {
+      "version": "4.17.17",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
+      "integrity": "sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.33",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
+      "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
     },
     "@types/fhir": {
       "version": "0.0.35",
@@ -11161,6 +11276,12 @@
       "version": "7.0.11",
       "dev": true
     },
+    "@types/mime": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
+      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
+      "dev": true
+    },
     "@types/node": {
       "version": "18.11.5"
     },
@@ -11168,9 +11289,31 @@
       "version": "2.7.1",
       "dev": true
     },
+    "@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "dev": true
+    },
+    "@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "dev": true
+    },
     "@types/semver": {
       "version": "7.3.13",
       "dev": true
+    },
+    "@types/serve-static": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
+      "dev": true,
+      "requires": {
+        "@types/mime": "*",
+        "@types/node": "*"
+      }
     },
     "@types/stack-utils": {
       "version": "2.0.1",
@@ -12396,6 +12539,8 @@
     },
     "express": {
       "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
       "requires": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@shelf/jest-mongodb": "^4.1.4",
+    "@types/express": "^4.17.17",
     "@types/fhir": "^0.0.35",
     "@types/jest": "^29.2.3",
     "@types/node": "^18.11.5",
@@ -45,6 +46,7 @@
   "dependencies": {
     "@projecttacoma/node-fhir-server-core": "^2.2.8",
     "dotenv": "^16.0.3",
+    "express": "^4.18.2",
     "fqm-execution": "^1.0.4",
     "mongodb": "^4.12.1",
     "uuid": "^9.0.0",

--- a/scripts/dbSetup.ts
+++ b/scripts/dbSetup.ts
@@ -2,6 +2,7 @@ import { Connection } from '../src/db/Connection';
 import * as fs from 'fs';
 import * as dotenv from 'dotenv';
 import { MongoError } from 'mongodb';
+import { createResource } from '../src/db/dbOperations';
 
 dotenv.config();
 
@@ -92,16 +93,6 @@ async function insertFHIRModelInfoLibrary() {
   const fhirModelInfoLibrary: fhir4.Library = JSON.parse(fhirModelInfo); 
 
   await createResource(fhirModelInfoLibrary, 'Library');
-}
-
-/*
- * Inserts one data object into database with specified FHIR resource type
- */
-export async function createResource(data: fhir4.FhirResource, resourceType: string) {
-  const collection = Connection.db.collection<fhir4.FhirResource>(resourceType);
-  console.log(`Inserting ${resourceType}/${data.id} into database`);
-  await collection.insertOne(data);
-  return { id: data.id };
 }
 
 if (process.argv[2] === 'delete') {

--- a/scripts/dbSetup.ts
+++ b/scripts/dbSetup.ts
@@ -97,7 +97,7 @@ async function insertFHIRModelInfoLibrary() {
 /*
  * Inserts one data object into database with specified FHIR resource type
  */
-async function createResource(data: fhir4.FhirResource, resourceType: string) {
+export async function createResource(data: fhir4.FhirResource, resourceType: string) {
   const collection = Connection.db.collection<fhir4.FhirResource>(resourceType);
   console.log(`Inserting ${resourceType}/${data.id} into database`);
   await collection.insertOne(data);

--- a/src/config/capabilityStatementResources.json
+++ b/src/config/capabilityStatementResources.json
@@ -127,7 +127,7 @@
             "valueCode" : "SHALL"
           }],
           "name" : "submit",
-          "definition" : "example.com"
+          "definition" : "http://hl7.org/fhir/us/cqfmeasures/STU3/measure-repository-service.html#submit"
         }
       ]
     },

--- a/src/config/capabilityStatementResources.json
+++ b/src/config/capabilityStatementResources.json
@@ -267,7 +267,7 @@
             "valueCode" : "SHALL"
           }],
           "name" : "submit",
-          "definition" : "example.com"
+          "definition" : "http://hl7.org/fhir/us/cqfmeasures/STU3/measure-repository-service.html#submit"
         }
       ]
     }

--- a/src/config/capabilityStatementResources.json
+++ b/src/config/capabilityStatementResources.json
@@ -120,6 +120,14 @@
           }],
           "name" : "package",
           "definition" : "http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Library-package"
+        },
+        {
+          "extension" : [{
+            "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+            "valueCode" : "SHALL"
+          }],
+          "name" : "submit",
+          "definition" : "example.com"
         }
       ]
     },
@@ -252,6 +260,14 @@
           }],
           "name" : "data-requirements",
           "definition" : "http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Measure-data-requirements"
+        },
+        {
+          "extension" : [{
+            "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+            "valueCode" : "SHALL"
+          }],
+          "name" : "submit",
+          "definition" : "example.com"
         }
       ]
     }

--- a/src/config/serverConfig.ts
+++ b/src/config/serverConfig.ts
@@ -16,7 +16,8 @@ const customCapabilityStatement = (): fhir4.CapabilityStatement => {
     publisher: 'The MITRE Corporation',
     instantiates: [
       'http://hl7.org/fhir/us/cqfmeasures/CapabilityStatement/shareable-measure-repository',
-      'http://hl7.org/fhir/us/cqfmeasures/CapabilityStatement/publishable-measure-repository'
+      'http://hl7.org/fhir/us/cqfmeasures/CapabilityStatement/publishable-measure-repository',
+      'http://hl7.org/fhir/us/cqfmeasures/CapabilityStatement/authoring-measure-repository'
     ],
     kind: 'instance',
     implementation: {
@@ -81,6 +82,16 @@ export const serverConfig: ServerConfig = {
           route: '/:id/$data-requirements',
           method: 'POST',
           reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Measure-data-requirements'
+        },
+        {
+          name: 'submit',
+          route: '/$submit',
+          method: 'POST'
+        },
+        {
+          name: 'submit',
+          route: '/:id/$submit',
+          method: 'POST'
         }
       ]
     },
@@ -111,6 +122,16 @@ export const serverConfig: ServerConfig = {
           route: '/:id/$package',
           method: 'POST',
           reference: 'http://hl7.org/fhir/us/cqfmeasures/OperationDefinition/Library-package'
+        },
+        {
+          name: 'submit',
+          route: '/$submit',
+          method: 'POST'
+        },
+        {
+          name: 'submit',
+          route: '/:id/$submit',
+          method: 'POST'
         }
       ]
     }

--- a/src/config/serverConfig.ts
+++ b/src/config/serverConfig.ts
@@ -25,6 +25,9 @@ const customCapabilityStatement = (): fhir4.CapabilityStatement => {
     },
     fhirVersion: base_version.replace(/_/g, '.'),
     format: ['application/fhir+json'],
+    // NOTE: the definitions for authoring measure repository operations
+    // are not FHIR OperationDefinitions, and we should update the JSON
+    // when FHIR OperationDefinitions are available
     rest: [capabilityStatementResources]
   });
 };

--- a/src/db/dbOperations.ts
+++ b/src/db/dbOperations.ts
@@ -20,3 +20,13 @@ export async function findResourcesWithQuery<T extends fhir4.FhirResource>(
   const collection = Connection.db.collection(resourceType);
   return collection.find<T>(query, { projection: { _id: 0 } }).toArray();
 }
+
+/*
+ * Inserts one data object into database with specified FHIR resource type
+ */
+export async function createResource(data: fhir4.FhirResource, resourceType: string) {
+  const collection = Connection.db.collection<fhir4.FhirResource>(resourceType);
+  console.log(`Inserting ${resourceType}/${data.id} into database`);
+  await collection.insertOne(data);
+  return { id: data.id };
+}

--- a/src/db/dbOperations.ts
+++ b/src/db/dbOperations.ts
@@ -1,6 +1,8 @@
-import { FhirResourceType } from '@projecttacoma/node-fhir-server-core';
+import { loggers, FhirResourceType } from '@projecttacoma/node-fhir-server-core';
 import { Filter } from 'mongodb';
 import { Connection } from './Connection';
+
+const logger = loggers.get('default');
 
 /**
  * searches the database for the desired resource and returns the data
@@ -26,7 +28,7 @@ export async function findResourcesWithQuery<T extends fhir4.FhirResource>(
  */
 export async function createResource(data: fhir4.FhirResource, resourceType: string) {
   const collection = Connection.db.collection<fhir4.FhirResource>(resourceType);
-  console.log(`Inserting ${resourceType}/${data.id} into database`);
+  logger.info(`Inserting ${resourceType}/${data.id} into database`);
   await collection.insertOne(data);
   return { id: data.id };
 }

--- a/src/db/dbOperations.ts
+++ b/src/db/dbOperations.ts
@@ -1,5 +1,5 @@
 import { FhirResourceType } from '@projecttacoma/node-fhir-server-core';
-import { Filter, ObjectId } from 'mongodb';
+import { Filter } from 'mongodb';
 import { Connection } from './Connection';
 
 /**
@@ -19,10 +19,4 @@ export async function findResourcesWithQuery<T extends fhir4.FhirResource>(
 ) {
   const collection = Connection.db.collection(resourceType);
   return collection.find<T>(query, { projection: { _id: 0 } }).toArray();
-}
-
-export async function createResource(data: Partial<fhir4.FhirResource> & { _id: ObjectId }, resourceType: string) {
-  const collection = Connection.db.collection(resourceType);
-  await collection.insertOne(data);
-  return { id: data.id };
 }

--- a/src/db/dbOperations.ts
+++ b/src/db/dbOperations.ts
@@ -1,5 +1,5 @@
 import { FhirResourceType } from '@projecttacoma/node-fhir-server-core';
-import { Filter } from 'mongodb';
+import { Filter, ObjectId } from 'mongodb';
 import { Connection } from './Connection';
 
 /**
@@ -21,7 +21,7 @@ export async function findResourcesWithQuery<T extends fhir4.FhirResource>(
   return collection.find<T>(query, { projection: { _id: 0 } }).toArray();
 }
 
-export async function createResource(data: any, resourceType: string) {
+export async function createResource(data: Partial<fhir4.FhirResource> & { _id: ObjectId }, resourceType: string) {
   const collection = Connection.db.collection(resourceType);
   await collection.insertOne(data);
   return { id: data.id };

--- a/src/db/dbOperations.ts
+++ b/src/db/dbOperations.ts
@@ -26,18 +26,3 @@ export async function createResource(data: any, resourceType: string) {
   await collection.insertOne(data);
   return { id: data.id };
 }
-
-export async function updateResource(id: string, data: any, resourceType: string) {
-  const collection = Connection.db.collection(resourceType);
-  const results = await collection.replaceOne({ id }, data, { upsert: true });
-
-  // If the document cannot be created with the passed id, Mongo will throw an error
-  // before here, so should be ok to just return the passed id
-  // upsertedCount indicates that we have created a brand new document
-  if (results.upsertedCount === 1) {
-    return { id, created: true };
-  }
-
-  // value being present indicates an update, so set created flag to false
-  return { id, created: false };
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,15 @@ import { initialize, loggers } from '@projecttacoma/node-fhir-server-core';
 import * as dotenv from 'dotenv';
 import { serverConfig } from './config/serverConfig';
 import { Connection } from './db/Connection';
+import express from 'express';
 
 dotenv.config();
 
-const server = initialize(serverConfig);
+const app = express();
+app.use(express.json({ limit: '50mb', type: 'application/json+fhir' }));
+app.use(express.json({ limit: '50mb', type: 'application/fhir+json' }));
+
+const server = initialize(serverConfig, app);
 const logger = loggers.get('default');
 
 const port = process.env.PORT ? parseInt(process.env.PORT) : 3000;

--- a/src/services/LibraryService.ts
+++ b/src/services/LibraryService.ts
@@ -89,6 +89,6 @@ export class LibraryService implements Service<fhir4.Library> {
     await createResource(resource, 'Library');
     res.status(201);
     const location = `${constants.VERSIONS['4_0_1']}/Library/${resource.id}`;
-    res.set('Content-Location', `${process.env.HOST}/${process.env.PORT}/${location}`);
+    res.set('Content-Location', `${process.env.HOST}:${process.env.PORT}/${location}`);
   }
 }

--- a/src/services/LibraryService.ts
+++ b/src/services/LibraryService.ts
@@ -6,7 +6,13 @@ import { Service } from '../types/service';
 import { createLibraryPackageBundle, createSearchsetBundle } from '../util/bundleUtils';
 import { BadRequestError, ResourceNotFoundError } from '../util/errorUtils';
 import { getMongoQueryFromRequest } from '../util/queryUtils';
-import { extractIdentificationForQuery, gatherParams, validateParamIdSource, checkContentTypeHeader, checkExpectedResourceType } from '../util/inputUtils';
+import {
+  extractIdentificationForQuery,
+  gatherParams,
+  validateParamIdSource,
+  checkContentTypeHeader,
+  checkExpectedResourceType
+} from '../util/inputUtils';
 import { v4 as uuidv4 } from 'uuid';
 const logger = loggers.get('default');
 

--- a/src/services/LibraryService.ts
+++ b/src/services/LibraryService.ts
@@ -1,6 +1,7 @@
 import { loggers, RequestArgs, RequestCtx, constants } from '@projecttacoma/node-fhir-server-core';
-import { createResource, findResourceById, findResourcesWithQuery } from '../db/dbOperations';
+import { findResourceById, findResourcesWithQuery } from '../db/dbOperations';
 import { LibrarySearchArgs, PackageArgs, parseRequestSchema } from '../requestSchemas';
+import { createResource } from '../../scripts/dbSetup';
 import { Service } from '../types/service';
 import { createLibraryPackageBundle, createSearchsetBundle } from '../util/bundleUtils';
 import { BadRequestError, ResourceNotFoundError } from '../util/errorUtils';

--- a/src/services/LibraryService.ts
+++ b/src/services/LibraryService.ts
@@ -1,7 +1,7 @@
 import { loggers, RequestArgs, RequestCtx, constants } from '@projecttacoma/node-fhir-server-core';
 import { findResourceById, findResourcesWithQuery } from '../db/dbOperations';
 import { LibrarySearchArgs, PackageArgs, parseRequestSchema } from '../requestSchemas';
-import { createResource } from '../../scripts/dbSetup';
+import { createResource } from '../db/dbOperations';
 import { Service } from '../types/service';
 import { createLibraryPackageBundle, createSearchsetBundle } from '../util/bundleUtils';
 import { BadRequestError, ResourceNotFoundError } from '../util/errorUtils';
@@ -92,6 +92,6 @@ export class LibraryService implements Service<fhir4.Library> {
     await createResource(resource, 'Library');
     res.status(201);
     const location = `${constants.VERSIONS['4_0_1']}/Library/${resource.id}`;
-    res.set('Content-Location', `${process.env.HOST}:${process.env.PORT}/${location}`);
+    res.set('Location', location);
   }
 }

--- a/src/services/LibraryService.ts
+++ b/src/services/LibraryService.ts
@@ -86,9 +86,6 @@ export class LibraryService implements Service<fhir4.Library> {
       throw new BadRequestError(`The artifact must be in 'draft' status.`);
     }
 
-    // lastUpdated should be second because it should overwrite a meta.lastUpdated tag in the request body
-    resource['meta'] = { ...resource['meta'], lastUpdated: new Date().toISOString() };
-
     const res = req.res;
     // create new resource with server-defined id
     resource['id'] = uuidv4();

--- a/src/services/LibraryService.ts
+++ b/src/services/LibraryService.ts
@@ -58,4 +58,14 @@ export class LibraryService implements Service<fhir4.Library> {
 
     return createLibraryPackageBundle(query, parsedParams);
   }
+
+  /**
+   * result of sending a POST or PUT request to:
+   * {BASE_URL}/4_0_1/Measure/$submit or {BASE_URL}/4_0_1/Measure/:id/$submit
+   * POSTs/PUTs a new artifact in "draft" status. The operation results in an error if the artifact
+   * does not have status set to "draft."
+   */
+  async submit(args: RequestArgs, { req }: RequestCtx) {
+    return true;
+  }
 }

--- a/src/services/LibraryService.ts
+++ b/src/services/LibraryService.ts
@@ -62,8 +62,8 @@ export class LibraryService implements Service<fhir4.Library> {
 
   /**
    * result of sending a POST request to:
-   * {BASE_URL}/4_0_1/Library/$submit or a PUT request to: {BASE_URL}/4_0_1/Library/:id/$submit
-   * POSTs/PUTs a new artifact in "draft" status. The operation results in an error if the artifact
+   * {BASE_URL}/4_0_1/Library/$submit or {BASE_URL}/4_0_1/Library/:id/$submit
+   * POSTs a new artifact in "draft" status. The operation results in an error if the artifact
    * does not have status set to "draft."
    */
   async submit(args: RequestArgs, { req }: RequestCtx) {

--- a/src/services/LibraryService.ts
+++ b/src/services/LibraryService.ts
@@ -51,6 +51,11 @@ export class LibraryService implements Service<fhir4.Library> {
   async package(args: RequestArgs, { req }: RequestCtx) {
     logger.info(`${req.method} ${req.path}`);
 
+    if (req.method === 'POST') {
+      const contentType: string | undefined = req.headers['content-type'];
+      checkContentTypeHeader(contentType);
+    }
+
     const params = gatherParams(req.query, args.resource);
     validateParamIdSource(req.params.id, params.id);
 

--- a/src/services/MeasureService.ts
+++ b/src/services/MeasureService.ts
@@ -4,7 +4,13 @@ import { Service } from '../types/service';
 import { createMeasurePackageBundle, createSearchsetBundle } from '../util/bundleUtils';
 import { BadRequestError, ResourceNotFoundError } from '../util/errorUtils';
 import { getMongoQueryFromRequest } from '../util/queryUtils';
-import { extractIdentificationForQuery, gatherParams, validateParamIdSource, checkContentTypeHeader, checkExpectedResourceType } from '../util/inputUtils';
+import {
+  extractIdentificationForQuery,
+  gatherParams,
+  validateParamIdSource,
+  checkContentTypeHeader,
+  checkExpectedResourceType
+} from '../util/inputUtils';
 import { Calculator } from 'fqm-execution';
 import { MeasureSearchArgs, MeasureDataRequirementsArgs, PackageArgs, parseRequestSchema } from '../requestSchemas';
 import { v4 as uuidv4 } from 'uuid';

--- a/src/services/MeasureService.ts
+++ b/src/services/MeasureService.ts
@@ -8,7 +8,7 @@ import { extractIdentificationForQuery, gatherParams, validateParamIdSource, che
 import { Calculator } from 'fqm-execution';
 import { MeasureSearchArgs, MeasureDataRequirementsArgs, PackageArgs, parseRequestSchema } from '../requestSchemas';
 import { v4 as uuidv4 } from 'uuid';
-import { createResource } from '../../scripts/dbSetup';
+import { createResource } from '../db/dbOperations';
 
 const logger = loggers.get('default');
 
@@ -121,9 +121,9 @@ export class MeasureService implements Service<fhir4.Measure> {
     const res = req.res;
     // create new resource with server-defined id
     resource['id'] = uuidv4();
-    await createResource(resource, 'Library');
+    await createResource(resource, 'Measure');
     res.status(201);
-    const location = `${constants.VERSIONS['4_0_1']}/Library/${resource.id}`;
-    res.set('Content-Location', `${process.env.HOST}:${process.env.PORT}/${location}`);
+    const location = `${constants.VERSIONS['4_0_1']}/Measure/${resource.id}`;
+    res.set('Location', location);
   }
 }

--- a/src/services/MeasureService.ts
+++ b/src/services/MeasureService.ts
@@ -94,8 +94,8 @@ export class MeasureService implements Service<fhir4.Measure> {
 
   /**
    * result of sending a POST request to:
-   * {BASE_URL}/4_0_1/Measure/$submit or a PUT request to: {BASE_URL}/4_0_1/Measure/:id/$submit
-   * POSTs/PUTs a new artifact in "draft" status. The operation results in an error if the artifact
+   * {BASE_URL}/4_0_1/Measure/$submit or {BASE_URL}/4_0_1/Measure/:id/$submit
+   * POSTs a new artifact in "draft" status. The operation results in an error if the artifact
    * does not have status set to "draft."
    */
   async submit(args: RequestArgs, { req }: RequestCtx) {

--- a/src/services/MeasureService.ts
+++ b/src/services/MeasureService.ts
@@ -121,6 +121,6 @@ export class MeasureService implements Service<fhir4.Measure> {
     await createResource(resource, 'Library');
     res.status(201);
     const location = `${constants.VERSIONS['4_0_1']}/Library/${resource.id}`;
-    res.set('Content-Location', `${process.env.HOST}/${process.env.PORT}/${location}`);
+    res.set('Content-Location', `${process.env.HOST}:${process.env.PORT}/${location}`);
   }
 }

--- a/src/services/MeasureService.ts
+++ b/src/services/MeasureService.ts
@@ -1,5 +1,5 @@
 import { loggers, RequestArgs, RequestCtx, constants } from '@projecttacoma/node-fhir-server-core';
-import { findResourceById, findResourcesWithQuery, createResource } from '../db/dbOperations';
+import { findResourceById, findResourcesWithQuery } from '../db/dbOperations';
 import { Service } from '../types/service';
 import { createMeasurePackageBundle, createSearchsetBundle } from '../util/bundleUtils';
 import { BadRequestError, ResourceNotFoundError } from '../util/errorUtils';
@@ -8,6 +8,7 @@ import { extractIdentificationForQuery, gatherParams, validateParamIdSource, che
 import { Calculator } from 'fqm-execution';
 import { MeasureSearchArgs, MeasureDataRequirementsArgs, PackageArgs, parseRequestSchema } from '../requestSchemas';
 import { v4 as uuidv4 } from 'uuid';
+import { createResource } from '../../scripts/dbSetup';
 
 const logger = loggers.get('default');
 

--- a/src/services/MeasureService.ts
+++ b/src/services/MeasureService.ts
@@ -118,9 +118,6 @@ export class MeasureService implements Service<fhir4.Measure> {
       throw new BadRequestError(`The artifact must be in 'draft' status.`);
     }
 
-    // lastUpdated should be second because it should overwrite a meta.lastUpdated tag in the request body
-    resource['meta'] = { ...resource['meta'], lastUpdated: new Date().toISOString() };
-
     const res = req.res;
     // create new resource with server-defined id
     resource['id'] = uuidv4();

--- a/src/services/MeasureService.ts
+++ b/src/services/MeasureService.ts
@@ -53,6 +53,11 @@ export class MeasureService implements Service<fhir4.Measure> {
   async package(args: RequestArgs, { req }: RequestCtx) {
     logger.info(`${req.method} ${req.path}`);
 
+    if (req.method === 'POST') {
+      const contentType: string | undefined = req.headers['content-type'];
+      checkContentTypeHeader(contentType);
+    }
+
     const params = gatherParams(req.query, args.resource);
     validateParamIdSource(req.params.id, params.id);
 

--- a/src/util/inputUtils.ts
+++ b/src/util/inputUtils.ts
@@ -51,10 +51,10 @@ export function extractIdentificationForQuery(args: RequestArgs, params: Record<
 /**
  * Checks that the content-type from the request headers accepts json + fhir.
  */
-export function checkContentTypeHeader(contentType: string | undefined) {
+export function checkContentTypeHeader(contentType?: string) {
   if (contentType !== 'application/json+fhir' && contentType !== 'application/fhir+json') {
     throw new BadRequestError(
-      'Ensure Content-Type is set to application/json+fhir or to application/json+fhir in headers'
+      'Ensure Content-Type is set to application/json+fhir or to application/fhir+json in headers'
     );
   }
 }

--- a/src/util/inputUtils.ts
+++ b/src/util/inputUtils.ts
@@ -59,6 +59,9 @@ export function checkContentTypeHeader(contentType: string | undefined) {
   }
 }
 
+/**
+ * Checks that the type of the resource in the body matches the resource type we expect.
+ */
 export function checkExpectedResourceType(resourceType: string, expectedResourceType: FhirResourceType) {
   if (resourceType !== expectedResourceType) {
     throw new BadRequestError(`Expected resourceType '${expectedResourceType}' in body. Received '${resourceType}'.`);

--- a/src/util/inputUtils.ts
+++ b/src/util/inputUtils.ts
@@ -1,4 +1,4 @@
-import { RequestArgs, RequestQuery } from '@projecttacoma/node-fhir-server-core';
+import { RequestArgs, RequestQuery, FhirResourceType } from '@projecttacoma/node-fhir-server-core';
 import { Filter } from 'mongodb';
 import { BadRequestError } from './errorUtils';
 
@@ -47,4 +47,20 @@ export function extractIdentificationForQuery(args: RequestArgs, params: Record<
   if (identifier) query.identifier = identifier;
 
   return query;
+}
+/**
+ * Checks that the content-type from the request headers accepts json + fhir.
+ */
+export function checkContentTypeHeader(contentType: string | undefined) {
+  if (contentType !== 'application/json+fhir' && contentType !== 'application/fhir+json') {
+    throw new BadRequestError(
+      'Ensure Content-Type is set to application/json+fhir or to application/fhir+json in headers'
+    );
+  }
+}
+
+export function checkExpectedResourceType(resourceType: string, expectedResourceType: FhirResourceType) {
+  if (resourceType !== expectedResourceType) {
+    throw new BadRequestError(`Expected resourceType '${expectedResourceType}' in body. Received '${resourceType}'.`);
+  }
 }

--- a/src/util/inputUtils.ts
+++ b/src/util/inputUtils.ts
@@ -54,7 +54,7 @@ export function extractIdentificationForQuery(args: RequestArgs, params: Record<
 export function checkContentTypeHeader(contentType: string | undefined) {
   if (contentType !== 'application/json+fhir' && contentType !== 'application/fhir+json') {
     throw new BadRequestError(
-      'Ensure Content-Type is set to application/json+fhir or to application/fhir+json in headers'
+      'Ensure Content-Type is set to application/json+fhir or to application/json+fhir in headers'
     );
   }
 }

--- a/test/services/LibraryService.test.ts
+++ b/test/services/LibraryService.test.ts
@@ -391,11 +391,10 @@ describe('LibraryService', () => {
       await supertest(server.app)
         .post('/4_0_1/Library/$submit')
         .send({resourceType: 'Library', status: 'draft'})
-        .set('Accept', 'application/json+fhir')
         .set('content-type', 'application/json+fhir')
         .expect(201)
         .then(response => {
-          expect(response.headers['content-location']).toBeDefined();
+          expect(response.headers.location).toBeDefined();
         });
     });
 
@@ -403,11 +402,10 @@ describe('LibraryService', () => {
       await supertest(server.app)
         .post(`/4_0_1/Library/test-id/$submit`)
         .send({resourceType: 'Library', status: 'draft'})
-        .set('Accept', 'application/json+fhir')
         .set('content-type', 'application/json+fhir')
         .expect(201)
         .then(response => {
-          expect(response.headers['content-location']).toBeDefined();
+          expect(response.headers.location).toBeDefined();
         });
     });
 
@@ -415,7 +413,6 @@ describe('LibraryService', () => {
       await supertest(server.app)
         .post(`/4_0_1/Library/$submit`)
         .send({resourceType: 'Library', status: 'active'})
-        .set('Accept', 'application/json+fhir')
         .set('content-type', 'application/json+fhir')
         .expect(400)
         .then(response => {

--- a/test/services/LibraryService.test.ts
+++ b/test/services/LibraryService.test.ts
@@ -387,7 +387,7 @@ describe('LibraryService', () => {
   });
 
   describe('$submit', () => {
-    it('returns 201 status with populated content location when provided correct headers and FHIR Library', async () => {
+    it('returns 201 status with populated location when provided correct headers and FHIR Library', async () => {
       await supertest(server.app)
         .post('/4_0_1/Library/$submit')
         .send({resourceType: 'Library', status: 'draft'})
@@ -398,7 +398,7 @@ describe('LibraryService', () => {
         });
     });
 
-    it('returns 201 status with populated content location when id is represent in the path', async () => {
+    it('returns 201 status with populated location when id is represent in the path', async () => {
       await supertest(server.app)
         .post(`/4_0_1/Library/test-id/$submit`)
         .send({resourceType: 'Library', status: 'draft'})

--- a/test/services/LibraryService.test.ts
+++ b/test/services/LibraryService.test.ts
@@ -385,6 +385,48 @@ describe('LibraryService', () => {
         });
     });
   });
+
+  describe('$submit', () => {
+    it('returns 201 status with populated content location when provided correct headers and FHIR Library', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Library/$submit')
+        .send({resourceType: 'Library', status: 'draft'})
+        .set('Accept', 'application/json+fhir')
+        .set('content-type', 'application/fhir+json')
+        .expect(201)
+        .then(response => {
+          expect(response.headers['content-location']).toBeDefined();
+        });
+    });
+
+    it('returns 201 status with populated content location when id is represent in the path', async () => {
+      await supertest(server.app)
+        .post(`/4_0_1/Library/test-id/$submit`)
+        .send({resourceType: 'Library', status: 'draft'})
+        .set('Accept', 'application/json+fhir')
+        .set('content-type', 'application/fhir+json')
+        .expect(201)
+        .then(response => {
+          expect(response.headers['content-location']).toBeDefined();
+        });
+    });
+
+    it('throws a 400 error when the library is not in "draft" status', async () => {
+      await supertest(server.app)
+        .post(`/4_0_1/Library/$submit`)
+        .send({resourceType: 'Library', status: 'active'})
+        .set('Accept', 'application/json+fhir')
+        .set('content-type', 'application/fhir+json')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].code).toEqual('invalid');
+          expect(response.body.issue[0].details.text).toEqual(
+            `The artifact must be in 'draft' status.`
+          );
+        });
+    });
+  });
+
   afterAll(() => {
     return cleanUpTestDatabase();
   });

--- a/test/services/LibraryService.test.ts
+++ b/test/services/LibraryService.test.ts
@@ -392,7 +392,7 @@ describe('LibraryService', () => {
         .post('/4_0_1/Library/$submit')
         .send({resourceType: 'Library', status: 'draft'})
         .set('Accept', 'application/json+fhir')
-        .set('content-type', 'application/fhir+json')
+        .set('content-type', 'application/json+fhir')
         .expect(201)
         .then(response => {
           expect(response.headers['content-location']).toBeDefined();
@@ -404,7 +404,7 @@ describe('LibraryService', () => {
         .post(`/4_0_1/Library/test-id/$submit`)
         .send({resourceType: 'Library', status: 'draft'})
         .set('Accept', 'application/json+fhir')
-        .set('content-type', 'application/fhir+json')
+        .set('content-type', 'application/json+fhir')
         .expect(201)
         .then(response => {
           expect(response.headers['content-location']).toBeDefined();
@@ -416,7 +416,7 @@ describe('LibraryService', () => {
         .post(`/4_0_1/Library/$submit`)
         .send({resourceType: 'Library', status: 'active'})
         .set('Accept', 'application/json+fhir')
-        .set('content-type', 'application/fhir+json')
+        .set('content-type', 'application/json+fhir')
         .expect(400)
         .then(response => {
           expect(response.body.issue[0].code).toEqual('invalid');

--- a/test/services/MeasureService.test.ts
+++ b/test/services/MeasureService.test.ts
@@ -503,6 +503,47 @@ describe('MeasureService', () => {
     });
   });
 
+  describe('$submit', () => {
+    it('returns 201 status with populated content location when provided correct headers and FHIR Measure', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Measure/$submit')
+        .send({resourceType: 'Measure', status: 'draft'})
+        .set('Accept', 'application/json+fhir')
+        .set('content-type', 'application/fhir+json')
+        .expect(201)
+        .then(response => {
+          expect(response.headers['content-location']).toBeDefined();
+        });
+    });
+
+    it('returns 201 status with populated content location when id is represent in the path', async () => {
+      await supertest(server.app)
+        .post(`/4_0_1/Measure/test-id/$submit`)
+        .send({resourceType: 'Measure', status: 'draft'})
+        .set('Accept', 'application/json+fhir')
+        .set('content-type', 'application/fhir+json')
+        .expect(201)
+        .then(response => {
+          expect(response.headers['content-location']).toBeDefined();
+        });
+    });
+
+    it('throws a 400 error when the measure is not in "draft" status', async () => {
+      await supertest(server.app)
+        .post(`/4_0_1/Measure/$submit`)
+        .send({resourceType: 'Measure', status: 'active'})
+        .set('Accept', 'application/json+fhir')
+        .set('content-type', 'application/fhir+json')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].code).toEqual('invalid');
+          expect(response.body.issue[0].details.text).toEqual(
+            `The artifact must be in 'draft' status.`
+          );
+        });
+    });
+  });
+
   afterAll(() => {
     return cleanUpTestDatabase();
   });

--- a/test/services/MeasureService.test.ts
+++ b/test/services/MeasureService.test.ts
@@ -509,7 +509,7 @@ describe('MeasureService', () => {
         .post('/4_0_1/Measure/$submit')
         .send({resourceType: 'Measure', status: 'draft'})
         .set('Accept', 'application/json+fhir')
-        .set('content-type', 'application/fhir+json')
+        .set('content-type', 'application/json+fhir')
         .expect(201)
         .then(response => {
           expect(response.headers['content-location']).toBeDefined();
@@ -521,7 +521,7 @@ describe('MeasureService', () => {
         .post(`/4_0_1/Measure/test-id/$submit`)
         .send({resourceType: 'Measure', status: 'draft'})
         .set('Accept', 'application/json+fhir')
-        .set('content-type', 'application/fhir+json')
+        .set('content-type', 'application/json+fhir')
         .expect(201)
         .then(response => {
           expect(response.headers['content-location']).toBeDefined();
@@ -533,7 +533,7 @@ describe('MeasureService', () => {
         .post(`/4_0_1/Measure/$submit`)
         .send({resourceType: 'Measure', status: 'active'})
         .set('Accept', 'application/json+fhir')
-        .set('content-type', 'application/fhir+json')
+        .set('content-type', 'application/json+fhir')
         .expect(400)
         .then(response => {
           expect(response.body.issue[0].code).toEqual('invalid');

--- a/test/services/MeasureService.test.ts
+++ b/test/services/MeasureService.test.ts
@@ -508,11 +508,10 @@ describe('MeasureService', () => {
       await supertest(server.app)
         .post('/4_0_1/Measure/$submit')
         .send({resourceType: 'Measure', status: 'draft'})
-        .set('Accept', 'application/json+fhir')
         .set('content-type', 'application/json+fhir')
         .expect(201)
         .then(response => {
-          expect(response.headers['content-location']).toBeDefined();
+          expect(response.headers.location).toBeDefined();
         });
     });
 
@@ -520,11 +519,10 @@ describe('MeasureService', () => {
       await supertest(server.app)
         .post(`/4_0_1/Measure/test-id/$submit`)
         .send({resourceType: 'Measure', status: 'draft'})
-        .set('Accept', 'application/json+fhir')
         .set('content-type', 'application/json+fhir')
         .expect(201)
         .then(response => {
-          expect(response.headers['content-location']).toBeDefined();
+          expect(response.headers.location).toBeDefined();
         });
     });
 
@@ -532,7 +530,6 @@ describe('MeasureService', () => {
       await supertest(server.app)
         .post(`/4_0_1/Measure/$submit`)
         .send({resourceType: 'Measure', status: 'active'})
-        .set('Accept', 'application/json+fhir')
         .set('content-type', 'application/json+fhir')
         .expect(400)
         .then(response => {

--- a/test/services/MeasureService.test.ts
+++ b/test/services/MeasureService.test.ts
@@ -504,7 +504,7 @@ describe('MeasureService', () => {
   });
 
   describe('$submit', () => {
-    it('returns 201 status with populated content location when provided correct headers and FHIR Measure', async () => {
+    it('returns 201 status with populated location when provided correct headers and FHIR Measure', async () => {
       await supertest(server.app)
         .post('/4_0_1/Measure/$submit')
         .send({resourceType: 'Measure', status: 'draft'})
@@ -515,7 +515,7 @@ describe('MeasureService', () => {
         });
     });
 
-    it('returns 201 status with populated content location when id is represent in the path', async () => {
+    it('returns 201 status with populated location when id is represent in the path', async () => {
       await supertest(server.app)
         .post(`/4_0_1/Measure/test-id/$submit`)
         .send({resourceType: 'Measure', status: 'draft'})

--- a/test/util/inputUtils.test.ts
+++ b/test/util/inputUtils.test.ts
@@ -41,7 +41,7 @@ describe('checkContentTypeHeader', () => {
         issue: [
           expect.objectContaining({
             details: {
-              text: 'Ensure Content-Type is set to application/json+fhir or to application/json+fhir in headers'
+              text: 'Ensure Content-Type is set to application/json+fhir or to application/fhir+json in headers'
             }
           })
         ]

--- a/test/util/inputUtils.test.ts
+++ b/test/util/inputUtils.test.ts
@@ -1,4 +1,4 @@
-import { gatherParams } from '../../src/util/inputUtils';
+import { gatherParams, checkContentTypeHeader, checkExpectedResourceType } from '../../src/util/inputUtils';
 
 const VALID_QUERY = { url: 'http://example.com' };
 
@@ -25,3 +25,55 @@ describe('gatherParams', () => {
     expect(gatherParams(VALID_QUERY, POPULATED_PARAMETERS)).toEqual({ url: 'http://example.com', id: 'test' });
   });
 });
+
+describe('checkContentTypeHeader', () => {
+  it('does not throw an error when content-type is application/json+fhir', () => {
+    expect(() => {
+      checkContentTypeHeader('application/json+fhir')
+    }).not.toThrow();
+  });
+
+  it('throws BadRequestError when content-type is not application/json+fhir', () => {
+    const INVALID_CONTENT_TYPE = 'invalid';
+    expect(() => checkContentTypeHeader(INVALID_CONTENT_TYPE)).toThrow(
+      expect.objectContaining({
+        statusCode: 400,
+        issue: [
+          expect.objectContaining({
+            details: {
+              text: 'Ensure Content-Type is set to application/json+fhir or to application/json+fhir in headers'
+            }
+          })
+        ]
+      })
+    );
+  });
+});
+
+describe('checkExpectedResourceType', () => {
+  it('does not throw an error when resource type from body matches expected resource type', () => {
+    const BODY_RESOURCE_TYPE = 'Library';
+    const EXPECTED_RESOURCE_TYPE = 'Library';
+    expect(() => {
+      checkExpectedResourceType(BODY_RESOURCE_TYPE, EXPECTED_RESOURCE_TYPE)
+    }).not.toThrow();
+  });
+
+  it('throws BadRequestError when resource type from body does not match expected resource type from path', () => {
+    const BODY_RESOURCE_TYPE = 'Library';
+    const EXPECTED_RESOURCE_TYPE = 'Measure';
+    expect(() => checkExpectedResourceType(BODY_RESOURCE_TYPE, EXPECTED_RESOURCE_TYPE)).toThrow(
+      expect.objectContaining({
+        statusCode: 400,
+        issue: [
+          expect.objectContaining({
+            details: {
+              text: `Expected resourceType '${EXPECTED_RESOURCE_TYPE}' in body. Received '${BODY_RESOURCE_TYPE}'.`
+            }
+          })
+        ]
+      })
+    );
+  });
+});
+


### PR DESCRIPTION
# Summary
Exposes the `$submit` operation, which POSTs a new artifact in draft status.

## New Behavior
See [this portion of the spec](https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#submit) for a brief description of the operation. Since the description is not detailed (and no OperationDefinition exists for this operation), we make the following assumptions:

* This operation is supported for both Measures and Libraries
* The operation is defined as a `POST` to `/(Library|Measure)/$submit` or `/(Library|Measure)/[id]/$submit`. Although the spec says that this can be a `PUT`, operations that involve state changes must be invoked by a POST. Therefore, we may not be able to use `PUT` for such an operation (and it is not exposed as an allowable option in node-fhir-server-core when setting up profile routes). Therefore, this PR deals with the `POST` scenario only, and we can re-visit the `PUT` case after getting more clarification on the spec.
* It is assumed that there are no IN params.
* It is assumed that the response should be `201` status since this is essentially a FHIR create with an additional check for draft status.
* For now, we assume the presence of dependent artifacts.

That being said, we expect that when a user `POST`s a Measure/Library resource to one of the specified endpoints with a FHIR Measure/Library in the body that is in “draft” status, the resource will be created and stored. When a user `POST`s a Measure/Library resource to one of the specified endpoints with a FHIR Measure/Library in the body that is not in “draft” status, a `BadRequest` error is thrown.

## Code Changes
* Documentation updates - README and capability statement
    * In capability statement: the operation `definition` must be defined, which is supposed to be an `OperationDefinition` canonical. There are currently no operation definitions for the authoring measure repository operations, so I put this as “[example.com](http://example.com/)” for now.
* New routes for both `MeasureService` and `LibraryService` in `serverConfig.ts`
* New `submit` function in both `MeasureService` and `LibraryService` - checks for correct content type header and resource type, checks for draft status, and then creates resource via `insertOne` on the collection. Returns 201 status and location of the resource
* Unit tests for submit operation and related helper functions

# Testing Guidance
* Run unit tests
* Send `POST` to `http://localhost:3000/4_0_1/Library/$submit`
    * With Library in “draft” status —> get 201
    * With Library not in “draft” status —> get 400
* Send `POST` to `http://localhost:3000/4_0_1/Measure/$submit`
    * With Measure in “draft” status —> get 201
    * With Measure not in “draft” status —> get 400
* Repeat with `http://localhost:3000/4_0_1/Library/<id>/$submit` and `http://localhost:3000/4_0_1/Measure/<id>/$submit`