### PR TITLE
ZOD schema for

### DIFF
--- a/src/util/inputUtils.ts
+++ b/src/util/inputUtils.ts
@@ -1,4 +1,4 @@
-import { RequestArgs, RequestQuery, FhirResourceType } from '@projecttacoma/node-fhir-server-core';
+import { RequestArgs, RequestQuery } from '@projecttacoma/node-fhir-server-core';
 import { Filter } from 'mongodb';
 import { BadRequestError } from './errorUtils';
 
@@ -47,23 +47,4 @@ export function extractIdentificationForQuery(args: RequestArgs, params: Record<
   if (identifier) query.identifier = identifier;
 
   return query;
-}
-/**
- * Checks that the content-type from the request headers accepts json + fhir.
- */
-export function checkContentTypeHeader(contentType?: string) {
-  if (contentType !== 'application/json+fhir' && contentType !== 'application/fhir+json') {
-    throw new BadRequestError(
-      'Ensure Content-Type is set to application/json+fhir or to application/fhir+json in headers'
-    );
-  }
-}
-
-/**
- * Checks that the type of the resource in the body matches the resource type we expect.
- */
-export function checkExpectedResourceType(resourceType: string, expectedResourceType: FhirResourceType) {
-  if (resourceType !== expectedResourceType) {
-    throw new BadRequestError(`Expected resourceType '${expectedResourceType}' in body. Received '${resourceType}'.`);
-  }
 }

--- a/test/requestSchemas.test.ts
+++ b/test/requestSchemas.test.ts
@@ -1,6 +1,6 @@
 import { constants } from '@projecttacoma/node-fhir-server-core';
 import { IssueData, z } from 'zod';
-import { catchInvalidParams, catchMissingIdentifyingInfo } from '../src/requestSchemas';
+import { catchInvalidParams, catchMissingIdentifyingInfo, checkContentTypeHeader, checkExpectedResourceType, checkResourceDraftStatus } from '../src/requestSchemas';
 
 describe('requestSchemas', () => {
   describe('catchMissingIdentifyingInfo', () => {
@@ -56,5 +56,82 @@ describe('requestSchemas', () => {
       expect(addIssue.mock.calls).toHaveLength(1);
       expect(addIssue.mock.calls[0][0]).toEqual(expectedIssueData);
     });
+
+    afterEach(jest.clearAllMocks);
   });
+
+  describe('checkContentTypeHeader', () => {
+    it('calls addIssue if the content-type header does not accept json + fhir', () => {
+      const addIssue = jest.fn((arg: IssueData) => {
+        return;
+      });
+      checkContentTypeHeader({method: 'POST', headers: {'content-type': 'invalid'}}, {path: [], addIssue});
+      expect(addIssue.mock.calls[0][0]).toEqual({
+        code: z.ZodIssueCode.custom,
+        message: 'Ensure Content-Type is set to application/json+fhir or to application/fhir+json in headers'
+      });
+    })
+
+    it('does not call addIssue if the content-type header does accept json + fhir', () => {
+      const addIssue = jest.fn((arg: IssueData) => {
+        return;
+      });
+      checkContentTypeHeader({method: 'POST', headers: {'content-type': 'application/json+fhir'}}, {path: [], addIssue});
+      expect(addIssue.mock.calls).toHaveLength(0);
+    });
+
+    afterEach(jest.clearAllMocks);
+  })
+
+  describe('checkResourceDraftStatus', () => {
+    it('calls addIssue if the status is not draft', () => {
+      const addIssue = jest.fn((arg: IssueData) => {
+        return;
+      });
+      checkResourceDraftStatus({body: {status: 'active'}}, {path: [], addIssue});
+      expect(addIssue.mock.calls[0][0]).toEqual({
+        code: z.ZodIssueCode.custom,
+        message: "The artifact must be in 'draft' status."
+      });
+    })
+
+    it('does not call addIssue if the status is in draft', () => {
+      const addIssue = jest.fn((arg: IssueData) => {
+        return;
+      });
+      checkContentTypeHeader({body: {status: 'draft'}}, {path: [], addIssue});
+      expect(addIssue.mock.calls).toHaveLength(0);
+    });
+
+    afterEach(jest.clearAllMocks);
+  })
+
+  describe('checkExpectedResourceType', () => {
+    it('returns a function that calls addIssue when the resource in the body does not match the expected resource type', () => {
+      const addIssue = jest.fn((arg: IssueData) => {
+        return;
+      });
+      checkExpectedResourceType([], 'Library')({ body: {resourceType: 'Measure'}}, {path: [], addIssue});
+
+      expect(addIssue.mock.calls).toHaveLength(1);
+      expect(addIssue.mock.calls[0][0]).toEqual({
+        code: z.ZodIssueCode.custom,
+        message: "Expected resourceType 'Library' in body. Received 'Measure'."
+      });
+    })
+
+    it('returns a function that calls addIssue when passed-in checkFunction calls addIssue', () => {
+      const addIssue = jest.fn((arg: IssueData) => {
+        return;
+      });
+      const expectedIssueData = { code: z.ZodIssueCode.custom };
+      const testCheckFunction = (val: Record<string, any>, ctx: z.RefinementCtx) => {
+        addIssue(expectedIssueData);
+      };
+      checkExpectedResourceType([testCheckFunction], 'Library')({body: {resourceType: 'Library'}}, {path: [], addIssue});
+
+      expect(addIssue.mock.calls).toHaveLength(1);
+      expect(addIssue.mock.calls[0][0]).toEqual(expectedIssueData);
+    })
+  })
 });

--- a/test/util/inputUtils.test.ts
+++ b/test/util/inputUtils.test.ts
@@ -1,4 +1,4 @@
-import { gatherParams, checkContentTypeHeader, checkExpectedResourceType } from '../../src/util/inputUtils';
+import { gatherParams } from '../../src/util/inputUtils';
 
 const VALID_QUERY = { url: 'http://example.com' };
 
@@ -23,57 +23,6 @@ describe('gatherParams', () => {
 
   it('returns params included in both url and request body combined', () => {
     expect(gatherParams(VALID_QUERY, POPULATED_PARAMETERS)).toEqual({ url: 'http://example.com', id: 'test' });
-  });
-});
-
-describe('checkContentTypeHeader', () => {
-  it('does not throw an error when content-type is application/json+fhir', () => {
-    expect(() => {
-      checkContentTypeHeader('application/json+fhir')
-    }).not.toThrow();
-  });
-
-  it('throws BadRequestError when content-type is not application/json+fhir', () => {
-    const INVALID_CONTENT_TYPE = 'invalid';
-    expect(() => checkContentTypeHeader(INVALID_CONTENT_TYPE)).toThrow(
-      expect.objectContaining({
-        statusCode: 400,
-        issue: [
-          expect.objectContaining({
-            details: {
-              text: 'Ensure Content-Type is set to application/json+fhir or to application/fhir+json in headers'
-            }
-          })
-        ]
-      })
-    );
-  });
-});
-
-describe('checkExpectedResourceType', () => {
-  it('does not throw an error when resource type from body matches expected resource type', () => {
-    const BODY_RESOURCE_TYPE = 'Library';
-    const EXPECTED_RESOURCE_TYPE = 'Library';
-    expect(() => {
-      checkExpectedResourceType(BODY_RESOURCE_TYPE, EXPECTED_RESOURCE_TYPE)
-    }).not.toThrow();
-  });
-
-  it('throws BadRequestError when resource type from body does not match expected resource type from path', () => {
-    const BODY_RESOURCE_TYPE = 'Library';
-    const EXPECTED_RESOURCE_TYPE = 'Measure';
-    expect(() => checkExpectedResourceType(BODY_RESOURCE_TYPE, EXPECTED_RESOURCE_TYPE)).toThrow(
-      expect.objectContaining({
-        statusCode: 400,
-        issue: [
-          expect.objectContaining({
-            details: {
-              text: `Expected resourceType '${EXPECTED_RESOURCE_TYPE}' in body. Received '${BODY_RESOURCE_TYPE}'.`
-            }
-          })
-        ]
-      })
-    );
   });
 });
 


### PR DESCRIPTION
# Summary
This PR adds a ZOD schema for the $submit operation. Nat added the first ZOD schemas for the other operations in [this PR](https://github.com/projecttacoma/measure-repository-service/pull/16) (good reference). However, the $submit operation does not have any in-parameters, so the ZOD schema is used for other checks that we previously did in `inputUtils.ts` and the Library and Measure service files.

## New behavior
Rather than creating our own `BadRequestError` for content-type header checking, draft status checking, and resource type checking, these are now Zod schemas.

## Code changes
- `requestSchemas.ts` - adds three functions: `checkExpectedResourceType()`, `checkContentTypeHeader()`, and `checkResourceDraftStatus`. These all were previously in `inputUtils.ts` or the Library or Measure service files. Additionally, schemas were added for `CoreSubmitArgs`, `LibrarySubmitArgs`, and `MeasureSubmitArgs`.
- `LibraryService.ts` - replaced content-type, draft status, and resource type checking with a call to `parseRequestSchema`
- `MeasureService.ts` -  replaced content-type, draft status, and resource type checking with a call to `parseRequestSchema`
- `inputUtils.ts` - removed `checkContentTypeHeader()` and `checkExpectedResourceType()` (now in `requestSchemas.ts`
- `requestSchemas.test.ts` - added unit tests for the new functions 
- `inputUtils.test.ts` - removed unit tests for deleted functions

# Testing guidance
- I based a lot of organization loosely on what Nat did in the first ZOD PR (for example, having `checkExpectedResourceType` take catchFunctions as a parameter). Let me know if any of these decisions by me don't make sense or if there is a better way to organize them! 
- `npm run check`
- `npm run db:reset`
- `npm run db:loadBundle "ecqm-content-r4-2021/bundles/measure/ColorectalCancerScreeningsFHIR/ColorectalCancerScreeningsFHIR-bundle.json"`
- `npm start`
- Try all the requests in the included insomnia bundle and make sure all outcomes make sense

