### PR TITLE
Added content-type header check to data-requirements operation

### DIFF
--- a/src/services/LibraryService.ts
+++ b/src/services/LibraryService.ts
@@ -111,6 +111,11 @@ export class LibraryService implements Service<fhir4.Library> {
    * requires parameters id and/or url and/or identifier, but also supports version as supplemental (optional)
    */
   async dataRequirements(args: RequestArgs, { req }: RequestCtx) {
+    if (req.method === 'POST') {
+      const contentType: string | undefined = req.headers['content-type'];
+      checkContentTypeHeader(contentType);
+    }
+    
     const params = gatherParams(req.query, args.resource);
     validateParamIdSource(req.params.id, params.id);
     const query = extractIdentificationForQuery(args, params);

--- a/src/services/LibraryService.ts
+++ b/src/services/LibraryService.ts
@@ -115,7 +115,7 @@ export class LibraryService implements Service<fhir4.Library> {
       const contentType: string | undefined = req.headers['content-type'];
       checkContentTypeHeader(contentType);
     }
-    
+
     const params = gatherParams(req.query, args.resource);
     validateParamIdSource(req.params.id, params.id);
     const query = extractIdentificationForQuery(args, params);

--- a/src/services/MeasureService.ts
+++ b/src/services/MeasureService.ts
@@ -85,7 +85,7 @@ export class MeasureService implements Service<fhir4.Measure> {
       const contentType: string | undefined = req.headers['content-type'];
       checkContentTypeHeader(contentType);
     }
-    
+
     const params = gatherParams(req.query, args.resource);
     validateParamIdSource(req.params.id, params.id);
     const query = extractIdentificationForQuery(args, params);

--- a/src/services/MeasureService.ts
+++ b/src/services/MeasureService.ts
@@ -81,6 +81,11 @@ export class MeasureService implements Service<fhir4.Measure> {
    * requires parameters id and/or url and/or identifier, but also supports version as supplemental (optional)
    */
   async dataRequirements(args: RequestArgs, { req }: RequestCtx) {
+    if (req.method === 'POST') {
+      const contentType: string | undefined = req.headers['content-type'];
+      checkContentTypeHeader(contentType);
+    }
+    
     const params = gatherParams(req.query, args.resource);
     validateParamIdSource(req.params.id, params.id);
     const query = extractIdentificationForQuery(args, params);


### PR DESCRIPTION
# Summary
Added check for `content-type` header to the `$data-requirements` function.

## New behavior
Before, we didn't check that the `content-type` header for data-requirements POST requests was `application/json+fhir`, so when the `content-type` header didn't exist, we got the following error message: "Must provide identifying information via either id, url, or identifier parameters". Adding this check makes sure that the user receives the error pertaining to the missing header.

## Code changes
- `LibraryService.ts` - added check that ensures POST requests have `content-type` headers for application json + fhir (same as in the `$package` operation).
- `MeasureService.ts` - added check that ensures POST requests have `content-type` headers for application json + fhir (same as in the `$package` operation).

# Testing guidance
- `npm run check`
- Using Insomnia, send a POST request to http://localhost:3000/4_0_1/Measure/$data-requirements and http://localhost:3000/4_0_1/Library/$data-requirements with proper JSON body but without a content-type header and ensure that a 400 Bad Request error is thrown and the message pertains to the lack of content-type header for application/json+fhir.
