### PR TITLE
Ensure url specified when version specified for search

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The Measure Repository Service server supports `Library` and `Measure` resource 
 - status
 - title
 - url
-- version
+- version (can appear only in combination with a url search)
 
 ### Package
 

--- a/src/requestSchemas.ts
+++ b/src/requestSchemas.ts
@@ -92,7 +92,7 @@ export function catchMissingIdentifyingInfo(val: Record<string, any>, ctx: z.Ref
  * is specified.
  */
 export function catchVersionWithoutUrl(val: Record<string, any>, ctx: z.RefinementCtx) {
-  if (Object.keys(val).includes('version') && !Object.keys(val).includes('url')) {
+  if ('version' in val && !('url' in val)) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       params: { serverErrorCode: constants.ISSUE.CODE.INVALID },

--- a/test/services/LibraryService.test.ts
+++ b/test/services/LibraryService.test.ts
@@ -164,6 +164,20 @@ describe('LibraryService', () => {
           );
         });
     });
+
+    it('returns 400 when query contains version without url', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Library')
+        .query({ status: 'active', version: 'searchable'})
+        .set('Accept', 'application/json+fhir')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].code).toEqual('invalid');
+          expect(response.body.issue[0].details.text).toEqual(
+            'Version can only appear in combination with a url search'
+          );
+        });
+    });
   });
 
   describe('$package', () => {

--- a/test/services/MeasureService.test.ts
+++ b/test/services/MeasureService.test.ts
@@ -138,12 +138,12 @@ describe('MeasureService', () => {
     it('returns 200 and correct searchset bundle when query matches multiple resources', async () => {
       await supertest(server.app)
         .get('/4_0_1/Measure')
-        .query({ status: 'active', version: 'searchable' })
+        .query({ status: 'active' })
         .set('Accept', 'application/json+fhir')
         .expect(200)
         .then(response => {
           expect(response.body.resourceType).toEqual('Bundle');
-          expect(response.body.total).toEqual(2);
+          expect(response.body.total).toEqual(7);
           expect(response.body.entry).toEqual(
             expect.arrayContaining([
               expect.objectContaining<fhir4.BundleEntry>({
@@ -153,6 +153,20 @@ describe('MeasureService', () => {
                 resource: MEASURE_WITH_URL
               })
             ])
+          );
+        });
+    });
+
+    it('returns 400 when query contains version without url', async () => {
+      await supertest(server.app)
+        .get('/4_0_1/Measure')
+        .query({ status: 'active', version: 'searchable'})
+        .set('Accept', 'application/json+fhir')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].code).toEqual('invalid');
+          expect(response.body.issue[0].details.text).toEqual(
+            'Version can only appear in combination with a url search'
           );
         });
     });


### PR DESCRIPTION
# Summary
Section [10.2.1.5.2.1](https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#core-searches) of the measure repository spec states that for searches, `version` “can appear only in combination with a url search.” This PR requires that url be supplied alongside a version when a version is specified in a Measure/Library search.

## New behavior
When the client performs a `search` with a version and not a url, a `BadRequest` error is thrown explaining that a url must be supplied alongside the version.

## Code changes
* New function in `requestSchemas.ts` that throws a `BadRequest` error if a version is supplied for `search` without a url
* New unit tests in `LibraryService` and `MeasureService` to ensure a 400 error gets thrown when the search query contains version without a url
    * Updated test in `MeasureService` that supplied a version without a url (thus resulting in a 400 instead of the expected 200 status)

# Testing guidance
* Run unit tests
* Perform a `search` for Measures, given a version and not a url. Example: `GET http://localhost:3000/4_0_1/Measure?version=test`. You should receive a 400 error with text “Version can only appear in combination with a url search.” Test with a version and url and check that the error is not thrown.
* Repeat the same with Library (example: `GET http://localhost:3000/4_0_1/Library?version=test`)