### PR TITLE
remove periodStart and periodEnd parameters from Library data-require…

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The Measure Repository Service server supports the `Measure` and `Library` `$dat
 - version
 - identifier
 
-Supported optional parameters are:
+Supported optional parameters for `Measure` are:
 
 - periodStart
 - periodEnd

--- a/src/requestSchemas.ts
+++ b/src/requestSchemas.ts
@@ -139,16 +139,18 @@ export const CommonDataRequirementsArgs = IdentifyingParameters.extend({
   'include-dependencies': stringToBool,
   manifest: z.string(),
   parameters: z.string(),
-  periodEnd: checkDate,
-  periodStart: checkDate,
   'system-version': z.string()
 })
   .partial()
   .strict();
 
-export const MeasureDataRequirementsArgs = CommonDataRequirementsArgs.superRefine(
-  catchInvalidParams([catchMissingIdentifyingInfo], UNSUPPORTED_DATA_REQ_ARGS)
-);
+export const MeasureDataRequirementsArgs = CommonDataRequirementsArgs.extend({
+  periodEnd: checkDate,
+  periodStart: checkDate
+})
+  .partial()
+  .strict()
+  .superRefine(catchInvalidParams([catchMissingIdentifyingInfo], UNSUPPORTED_DATA_REQ_ARGS));
 
 export const LibraryDataRequirementsArgs = CommonDataRequirementsArgs.extend({
   expression: z.string()

--- a/src/services/LibraryService.ts
+++ b/src/services/LibraryService.ts
@@ -126,8 +126,6 @@ export class LibraryService implements Service<fhir4.Library> {
     const { libraryBundle, rootLibRef } = await createLibraryPackageBundle(query, parsedParams);
 
     const { results } = await Calculator.calculateLibraryDataRequirements(libraryBundle, {
-      ...(parsedParams.periodStart && { measurementPeriodStart: parsedParams.periodStart }),
-      ...(parsedParams.periodEnd && { measurementPeriodEnd: parsedParams.periodEnd }),
       ...(rootLibRef && { rootLibRef })
     });
 

--- a/test/services/LibraryService.test.ts
+++ b/test/services/LibraryService.test.ts
@@ -450,7 +450,7 @@ describe('LibraryService', () => {
       }
     });
 
-    it('returns 200 and a Library for a simple Library with url, version, dependencies and no period params', async () => {
+    it('returns 200 and a Library for a simple Library with url, version, dependencies', async () => {
       await supertest(server.app)
         .post('/4_0_1/Library/$data-requirements')
         .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: 'testLibraryWithDeps' }] })

--- a/test/services/LibraryService.test.ts
+++ b/test/services/LibraryService.test.ts
@@ -168,7 +168,7 @@ describe('LibraryService', () => {
     it('returns 400 when query contains version without url', async () => {
       await supertest(server.app)
         .get('/4_0_1/Library')
-        .query({ status: 'active', version: 'searchable'})
+        .query({ status: 'active', version: 'searchable' })
         .set('Accept', 'application/json+fhir')
         .expect(400)
         .then(response => {
@@ -486,18 +486,10 @@ describe('LibraryService', () => {
         });
     });
 
-    it('returns 200 with passed period parameters', async () => {
+    it('returns 200 with query params', async () => {
       await supertest(server.app)
-        .post('/4_0_1/Library/$data-requirements')
-        .send({
-          resourceType: 'Parameters',
-          parameter: [
-            { name: 'id', valueString: 'testLibraryWithDeps' },
-            { name: 'periodStart', valueDate: '2021-01-01' },
-            { name: 'periodEnd', valueDate: '2021-12-31' }
-          ]
-        })
-        .set('content-type', 'application/fhir+json')
+        .get('/4_0_1/Library/$data-requirements')
+        .query({ id: 'testLibraryWithDeps' })
         .expect(200)
         .then(response => {
           expect(response.body.resourceType).toEqual('Library');
@@ -508,33 +500,45 @@ describe('LibraryService', () => {
               resourceType: 'Bundle'
             }),
             expect.objectContaining({
-              measurementPeriodStart: '2021-01-01',
-              measurementPeriodEnd: '2021-12-31',
               rootLibRef: 'http://example.com/testLibraryWithDeps|0.0.1-test'
             })
           );
         });
     });
 
-    it('returns 200 with query params', async () => {
+    it('throws a 400 with passed period start', async () => {
       await supertest(server.app)
-        .get('/4_0_1/Library/$data-requirements')
-        .query({ id: 'testLibraryWithDeps', periodStart: '2021-01-01', periodEnd: '2021-12-31' })
-        .expect(200)
+        .post('/4_0_1/Library/$data-requirements')
+        .send({
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'id', valueString: 'testLibraryWithDeps' },
+            { name: 'periodStart', valueDate: '2021-01-01' }
+          ]
+        })
+        .set('content-type', 'application/fhir+json')
+        .expect(400)
         .then(response => {
-          expect(response.body.resourceType).toEqual('Library');
-          expect(response.body.type.coding[0].code).toEqual('module-definition');
-          expect(response.body.dataRequirement).toHaveLength(0);
-          expect(calc).toBeCalledWith(
-            expect.objectContaining({
-              resourceType: 'Bundle'
-            }),
-            expect.objectContaining({
-              measurementPeriodStart: '2021-01-01',
-              measurementPeriodEnd: '2021-12-31',
-              rootLibRef: 'http://example.com/testLibraryWithDeps|0.0.1-test'
-            })
-          );
+          expect(response.body.issue[0].code).toEqual('value');
+          expect(response.body.issue[0].details.text).toEqual(`Unrecognized key(s) in object: 'periodStart'`);
+        });
+    });
+
+    it('throws a 400 with passed period end', async () => {
+      await supertest(server.app)
+        .post('/4_0_1/Library/$data-requirements')
+        .send({
+          resourceType: 'Parameters',
+          parameter: [
+            { name: 'id', valueString: 'testLibraryWithDeps' },
+            { name: 'periodEnd', valueDate: '2021-12-31' }
+          ]
+        })
+        .set('content-type', 'application/fhir+json')
+        .expect(400)
+        .then(response => {
+          expect(response.body.issue[0].code).toEqual('value');
+          expect(response.body.issue[0].details.text).toEqual(`Unrecognized key(s) in object: 'periodEnd'`);
         });
     });
 


### PR DESCRIPTION
…ments

# Summary
Changed parameter checking to only allow periodStart and periodEnd for the Measure endpoint, and not the Library endpoint.

## New behavior
Server throws a 400 error when periodStart or periodEnd are included in the parameters for the Library data-requirements endpoint.

## Code changes
- Update to README to specify that periodStart and periodEnd are only applicable for the measure endpoint.
- Updated LibraryService no longer uses period in fqm-execution data-requirements call
- requestSchemas.ts moves period checking from CommonDataRequirementsArgs to MeasureDataRequirementsArgs
- Tests updated to reflect allowed parameters and specifically check for 400 for periodStart and periodEnd

# Testing guidance
See testing guidance for: https://github.com/projecttacoma/measure-repository-service/pull/18
Any request that has a period in the parameters should throw a 400. If you then delete the periodStart and periodEnd from the parameters, the request should work as expected (200 and appropriate library body returned).
